### PR TITLE
Fix closure of exported resource

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/cos/COSDocument.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/cos/COSDocument.java
@@ -69,12 +69,12 @@ public class COSDocument extends COSBase
      * Document trailer dictionary.
      */
     private COSDictionary trailer;
-
+    
     /**
      * Document signature dictionary.
      */
     private COSDictionary signDictionary = null;
-
+    
     /**
      * Signature interface.
      */
@@ -90,12 +90,12 @@ public class COSDocument extends COSBase
     private String headerString = "%PDF-" + version;
 
     private boolean warnMissingClose = true;
-
+    
     /** signal that document is already decrypted, e.g. with {@link NonSequentialPDFParser} */
     private boolean isDecrypted = false;
-
+    
     private long startXref;
-
+    
     private boolean closed = false;
 
     /**
@@ -113,7 +113,7 @@ public class COSDocument extends COSBase
      * @param forceParsingValue flag to skip malformed or otherwise unparseable
      *                     document content where possible
      */
-    public COSDocument(RandomAccess scratchFileValue, boolean forceParsingValue)
+    public COSDocument(RandomAccess scratchFileValue, boolean forceParsingValue) 
     {
         scratchFile = scratchFileValue;
         tmpFile = null;
@@ -131,7 +131,7 @@ public class COSDocument extends COSBase
      *                     document content where possible
      * @throws IOException if something went wrong
      */
-    public COSDocument(File scratchDir, boolean forceParsingValue) throws IOException
+    public COSDocument(File scratchDir, boolean forceParsingValue) throws IOException 
     {
         tmpFile = File.createTempFile("pdfbox-", ".tmp", scratchDir);
         scratchFile = new RandomAccessFile(tmpFile, "rw");
@@ -143,7 +143,7 @@ public class COSDocument extends COSBase
      *
      *  @throws IOException If there is an error creating the tmp file.
      */
-    public COSDocument() throws IOException
+    public COSDocument() throws IOException 
     {
         this(new RandomAccessBuffer(), false);
     }
@@ -156,7 +156,7 @@ public class COSDocument extends COSBase
      *
      * @throws IOException If there is an error creating the tmp file.
      */
-    public COSDocument(File scratchDir) throws IOException
+    public COSDocument(File scratchDir) throws IOException 
     {
         this(scratchDir, false);
     }
@@ -169,7 +169,7 @@ public class COSDocument extends COSBase
      *
      * @param file The random access file to use for storage.
      */
-    public COSDocument(RandomAccess file)
+    public COSDocument(RandomAccess file) 
     {
         this(file, false);
     }
@@ -297,7 +297,7 @@ public class COSDocument extends COSBase
     public void setVersion( float versionValue )
     {
         // update header string
-        if (versionValue != version)
+        if (versionValue != version) 
         {
             headerString = headerString.replaceFirst(String.valueOf(version), String.valueOf(versionValue));
         }
@@ -354,13 +354,13 @@ public class COSDocument extends COSBase
 
     /**
      * This will return the signature interface.
-     * @return the signature interface
+     * @return the signature interface 
      */
-    public SignatureInterface getSignatureInterface()
+    public SignatureInterface getSignatureInterface() 
     {
         return signatureInterface;
     }
-
+    
     /**
      * This will set the encryption dictionary, this should only be called when
      * encrypting the document.
@@ -410,7 +410,7 @@ public class COSDocument extends COSBase
                 COSArray fields = (COSArray)acroForm.getDictionaryObject(COSName.FIELDS);
                 if (fields != null)
                 {
-                    // Some fields may contain twice references to a single field.
+                    // Some fields may contain twice references to a single field. 
                     // This will prevent such double entries.
                     HashMap<COSObjectKey, COSDictionary> signatures = new HashMap<COSObjectKey, COSDictionary>();
                     for ( Object object : fields )
@@ -431,7 +431,7 @@ public class COSDocument extends COSBase
         }
         return Collections.emptyList();
     }
-
+    
     /**
      * This will get the document ID.
      *
@@ -451,12 +451,12 @@ public class COSDocument extends COSBase
     {
         getTrailer().setItem(COSName.ID, id);
     }
-
+    
     /**
      * Set the signature interface to the given value.
      * @param sigInterface the signature interface
      */
-    public void setSignatureInterface(SignatureInterface sigInterface)
+    public void setSignatureInterface(SignatureInterface sigInterface) 
     {
         signatureInterface = sigInterface;
     }
@@ -525,19 +525,16 @@ public class COSDocument extends COSBase
     }
 
     /**
-     * This will delete the tmp file.
-     *
-     * Given {@link #getScratchFile()} exists we cannot guarantee exclusive access on our
-     * own {@link #scratchFile} so closing it is fundamentally unsafe and causes random failures.
+     * This will close all storage and delete the tmp files.
      *
      *  @throws IOException If there is an error close resources.
-     *  @see https://issues.apache.org/jira/browse/PDFBOX-1586 for why scratchFile cannot be closed.
      */
     public void close() throws IOException
     {
-        if (!closed)
+        if (!closed) 
         {
-            if (tmpFile != null)
+            scratchFile.close();
+            if (tmpFile != null) 
             {
                 tmpFile.delete();
             }
@@ -554,9 +551,9 @@ public class COSDocument extends COSBase
     @Override
     protected void finalize() throws IOException
     {
-        if (!closed)
+        if (!closed) 
         {
-            if (warnMissingClose)
+            if (warnMissingClose) 
             {
                 LOG.warn( "Warning: You did not close a PDF Document" );
             }
@@ -680,9 +677,9 @@ public class COSDocument extends COSBase
     }
 
     /**
-     * This method set the startxref value of the document. This will only
+     * This method set the startxref value of the document. This will only 
      * be needed for incremental updates.
-     *
+     * 
      * @param startXrefValue the value for startXref
      */
     public void setStartXref(long startXrefValue)
@@ -692,7 +689,7 @@ public class COSDocument extends COSBase
 
     /**
      * Return the startXref Position of the parsed document. This will only be needed for incremental updates.
-     *
+     * 
      * @return a long with the old position of the startxref
      */
     public long getStartXref()
@@ -702,7 +699,7 @@ public class COSDocument extends COSBase
 
     /**
      * Determines it the trailer is a XRef stream or not.
-     *
+     * 
      * @return true if the trailer is a XRef stream
      */
     public boolean isXRefStream()

--- a/pdfbox/src/main/java/org/apache/pdfbox/cos/COSDocument.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/cos/COSDocument.java
@@ -69,12 +69,12 @@ public class COSDocument extends COSBase
      * Document trailer dictionary.
      */
     private COSDictionary trailer;
-    
+
     /**
      * Document signature dictionary.
      */
     private COSDictionary signDictionary = null;
-    
+
     /**
      * Signature interface.
      */
@@ -90,12 +90,12 @@ public class COSDocument extends COSBase
     private String headerString = "%PDF-" + version;
 
     private boolean warnMissingClose = true;
-    
+
     /** signal that document is already decrypted, e.g. with {@link NonSequentialPDFParser} */
     private boolean isDecrypted = false;
-    
+
     private long startXref;
-    
+
     private boolean closed = false;
 
     /**
@@ -113,7 +113,7 @@ public class COSDocument extends COSBase
      * @param forceParsingValue flag to skip malformed or otherwise unparseable
      *                     document content where possible
      */
-    public COSDocument(RandomAccess scratchFileValue, boolean forceParsingValue) 
+    public COSDocument(RandomAccess scratchFileValue, boolean forceParsingValue)
     {
         scratchFile = scratchFileValue;
         tmpFile = null;
@@ -131,7 +131,7 @@ public class COSDocument extends COSBase
      *                     document content where possible
      * @throws IOException if something went wrong
      */
-    public COSDocument(File scratchDir, boolean forceParsingValue) throws IOException 
+    public COSDocument(File scratchDir, boolean forceParsingValue) throws IOException
     {
         tmpFile = File.createTempFile("pdfbox-", ".tmp", scratchDir);
         scratchFile = new RandomAccessFile(tmpFile, "rw");
@@ -143,7 +143,7 @@ public class COSDocument extends COSBase
      *
      *  @throws IOException If there is an error creating the tmp file.
      */
-    public COSDocument() throws IOException 
+    public COSDocument() throws IOException
     {
         this(new RandomAccessBuffer(), false);
     }
@@ -156,7 +156,7 @@ public class COSDocument extends COSBase
      *
      * @throws IOException If there is an error creating the tmp file.
      */
-    public COSDocument(File scratchDir) throws IOException 
+    public COSDocument(File scratchDir) throws IOException
     {
         this(scratchDir, false);
     }
@@ -169,7 +169,7 @@ public class COSDocument extends COSBase
      *
      * @param file The random access file to use for storage.
      */
-    public COSDocument(RandomAccess file) 
+    public COSDocument(RandomAccess file)
     {
         this(file, false);
     }
@@ -297,7 +297,7 @@ public class COSDocument extends COSBase
     public void setVersion( float versionValue )
     {
         // update header string
-        if (versionValue != version) 
+        if (versionValue != version)
         {
             headerString = headerString.replaceFirst(String.valueOf(version), String.valueOf(versionValue));
         }
@@ -354,13 +354,13 @@ public class COSDocument extends COSBase
 
     /**
      * This will return the signature interface.
-     * @return the signature interface 
+     * @return the signature interface
      */
-    public SignatureInterface getSignatureInterface() 
+    public SignatureInterface getSignatureInterface()
     {
         return signatureInterface;
     }
-    
+
     /**
      * This will set the encryption dictionary, this should only be called when
      * encrypting the document.
@@ -410,7 +410,7 @@ public class COSDocument extends COSBase
                 COSArray fields = (COSArray)acroForm.getDictionaryObject(COSName.FIELDS);
                 if (fields != null)
                 {
-                    // Some fields may contain twice references to a single field. 
+                    // Some fields may contain twice references to a single field.
                     // This will prevent such double entries.
                     HashMap<COSObjectKey, COSDictionary> signatures = new HashMap<COSObjectKey, COSDictionary>();
                     for ( Object object : fields )
@@ -431,7 +431,7 @@ public class COSDocument extends COSBase
         }
         return Collections.emptyList();
     }
-    
+
     /**
      * This will get the document ID.
      *
@@ -451,12 +451,12 @@ public class COSDocument extends COSBase
     {
         getTrailer().setItem(COSName.ID, id);
     }
-    
+
     /**
      * Set the signature interface to the given value.
      * @param sigInterface the signature interface
      */
-    public void setSignatureInterface(SignatureInterface sigInterface) 
+    public void setSignatureInterface(SignatureInterface sigInterface)
     {
         signatureInterface = sigInterface;
     }
@@ -525,16 +525,19 @@ public class COSDocument extends COSBase
     }
 
     /**
-     * This will close all storage and delete the tmp files.
+     * This will delete the tmp file.
+     *
+     * Given {@link #getScratchFile()} exists we cannot guarantee exclusive access on our
+     * own {@link #scratchFile} so closing it is fundamentally unsafe and causes random failures.
      *
      *  @throws IOException If there is an error close resources.
+     *  @see https://issues.apache.org/jira/browse/PDFBOX-1586 for why scratchFile cannot be closed.
      */
     public void close() throws IOException
     {
-        if (!closed) 
+        if (!closed)
         {
-            scratchFile.close();
-            if (tmpFile != null) 
+            if (tmpFile != null)
             {
                 tmpFile.delete();
             }
@@ -551,9 +554,9 @@ public class COSDocument extends COSBase
     @Override
     protected void finalize() throws IOException
     {
-        if (!closed) 
+        if (!closed)
         {
-            if (warnMissingClose) 
+            if (warnMissingClose)
             {
                 LOG.warn( "Warning: You did not close a PDF Document" );
             }
@@ -677,9 +680,9 @@ public class COSDocument extends COSBase
     }
 
     /**
-     * This method set the startxref value of the document. This will only 
+     * This method set the startxref value of the document. This will only
      * be needed for incremental updates.
-     * 
+     *
      * @param startXrefValue the value for startXref
      */
     public void setStartXref(long startXrefValue)
@@ -689,7 +692,7 @@ public class COSDocument extends COSBase
 
     /**
      * Return the startXref Position of the parsed document. This will only be needed for incremental updates.
-     * 
+     *
      * @return a long with the old position of the startxref
      */
     public long getStartXref()
@@ -699,7 +702,7 @@ public class COSDocument extends COSBase
 
     /**
      * Determines it the trailer is a XRef stream or not.
-     * 
+     *
      * @return true if the trailer is a XRef stream
      */
     public boolean isXRefStream()


### PR DESCRIPTION
This fixes https://issues.apache.org/jira/browse/PDFBOX-1586 although there will be an underlying problem which has not been inspected. Solves problem of crashes when saving split fragments from a large document,
