### PR TITLE
Fix PDFBOX-2428 in FontBox 1.8

### DIFF
--- a/fontbox/src/main/java/org/apache/fontbox/ttf/HorizontalMetricsTable.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/HorizontalMetricsTable.java
@@ -47,20 +47,37 @@ public class HorizontalMetricsTable extends TTFTable
         int numHMetrics = hHeader.getNumberOfHMetrics();
         int numGlyphs = ttf.getNumberOfGlyphs();
         
+        int bytesRead = 0;
         advanceWidth = new int[ numHMetrics ];
         leftSideBearing = new short[ numHMetrics ];
         for( int i=0; i<numHMetrics; i++ )
         {
             advanceWidth[i] = data.readUnsignedShort();
             leftSideBearing[i] = data.readSignedShort();
+            bytesRead += 4;
         }
         
-        int numberNonHorizontal = numGlyphs - numHMetrics;
-        nonHorizontalLeftSideBearing = new short[ numberNonHorizontal ];
-        for( int i=0; i<numberNonHorizontal; i++ )
+        if (bytesRead < getLength()) 
         {
-            nonHorizontalLeftSideBearing[i] = data.readSignedShort();
+            int numberNonHorizontal = numGlyphs - numHMetrics;
+            
+            // handle bad fonts with too many hmetrics
+            if (numberNonHorizontal < 0) 
+            {
+                numberNonHorizontal = numGlyphs;
+            }
+            
+            nonHorizontalLeftSideBearing = new short[numberNonHorizontal];
+            for (int i = 0; i < numberNonHorizontal; i++) 
+            {
+                if (bytesRead < getLength()) 
+                {
+                    nonHorizontalLeftSideBearing[i] = data.readSignedShort();
+                    bytesRead += 2;
+                }
+            }
         }
+        
         initialized = true;
     }
     /**


### PR DESCRIPTION
PDFBOX-2428 ("An error occured when reading table hmtx") is fixed in FontBox 2.0-SNAPSHOT already. Are there any plans to also release a fixed 1.8.x version? This pull request contains the proposed fix for 1.8 (backported from 2.0-SNAPSHOT).
