### PR TITLE
Change to use media box for page size instead of cropbox.

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/contentstream/PDFStreamEngine.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/contentstream/PDFStreamEngine.java
@@ -127,7 +127,7 @@ public abstract class PDFStreamEngine
         }
         currentPage = page;
         graphicsStack.clear();
-        graphicsStack.push(new PDGraphicsState(page.getCropBox()));
+        graphicsStack.push(new PDGraphicsState(page.getMediaBox()));
         textMatrix = null;
         textLineMatrix = null;
         resources = null;

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDPage.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDPage.java
@@ -241,7 +241,7 @@ public class PDPage implements COSObjectable, PDContentStream
     @Override
     public PDRectangle getBBox()
     {
-        return getCropBox();
+        return getMediaBox();
     }
 
     @Override

--- a/pdfbox/src/main/java/org/apache/pdfbox/text/PDFTextStreamEngine.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/text/PDFTextStreamEngine.java
@@ -113,7 +113,7 @@ class PDFTextStreamEngine extends PDFStreamEngine
     public void processPage(PDPage page) throws IOException
     {
         this.pageRotation = page.getRotation();
-        this.pageSize = page.getCropBox();
+        this.pageSize = page.getMediaBox();
         super.processPage(page);
     }
 


### PR DESCRIPTION
For PDF documents where media box is larger or smaller than crop box the content get squeezed or stretched.

For PDF content the media box should be used as the page size. 

More information about this at 
http://www.prepressure.com/pdf/basics/page-boxes
