### PR TITLE
Mark transparency groups

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/documentinterchange/markedcontent/PDMarkedContent.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/documentinterchange/markedcontent/PDMarkedContent.java
@@ -53,6 +53,7 @@ public class PDMarkedContent
     private final String tag;
     private final COSDictionary properties;
     private final List<Object> contents;
+    private boolean visible = true;
 
 
     /**
@@ -197,6 +198,26 @@ public class PDMarkedContent
             .append(", properties=").append(this.properties);
         sb.append(", contents=").append(this.contents);
         return sb.toString();
+    }
+
+    /**
+     * Is this marked content a transparency group.
+     *
+     * @return boolean True if the marked content is a transparency group.
+     */
+    public boolean isTransparencyGroup()
+    {
+        return transparencyGroup;
+    }
+
+    /**
+     * Set flag if this marked content is a transparency group.
+     *
+     * $param visible True if the marked content is a transparency group.
+     */
+    public void setTransparencyGroup(boolean transparencyGroup)
+    {
+        this.transparencyGroup = transparencyGroup;
     }
 
 }

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/documentinterchange/markedcontent/PDMarkedContent.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/documentinterchange/markedcontent/PDMarkedContent.java
@@ -53,8 +53,7 @@ public class PDMarkedContent
     private final String tag;
     private final COSDictionary properties;
     private final List<Object> contents;
-    private boolean visible = true;
-
+    private boolean transparencyGroup = true;
 
     /**
      * Creates a new marked content object.

--- a/pdfbox/src/main/java/org/apache/pdfbox/text/PDFMarkedContentExtractor.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/text/PDFMarkedContentExtractor.java
@@ -27,6 +27,7 @@ import org.apache.pdfbox.cos.COSDictionary;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.documentinterchange.markedcontent.PDMarkedContent;
 import org.apache.pdfbox.pdmodel.graphics.PDXObject;
+import org.apache.pdfbox.pdmodel.graphics.form.PDTransparencyGroup;
 import org.apache.pdfbox.contentstream.operator.markedcontent.BeginMarkedContentSequence;
 import org.apache.pdfbox.contentstream.operator.markedcontent.BeginMarkedContentSequenceWithProperties;
 import org.apache.pdfbox.contentstream.operator.markedcontent.DrawObject;

--- a/pdfbox/src/main/java/org/apache/pdfbox/text/PDFMarkedContentExtractor.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/text/PDFMarkedContentExtractor.java
@@ -115,6 +115,31 @@ public class PDFMarkedContentExtractor extends PDFTextStreamEngine
     }
 
     /**
+     * Return the currently stacked marked content.
+     *
+     * @return the currently stacked marked content.
+     */
+    public Stack<PDMarkedContent> getCurrentMarkedContentStack()
+    {
+        return currentMarkedContents;
+    }
+
+    /**
+     * Handle transparency groups. In case of an instance then send it up stream and then set
+     * the visible flag to false.
+     *
+     * @param group The transparency group.
+     */
+    @Override
+    protected void processTransparencyGroup(PDTransparencyGroup group) throws IOException
+    {
+        super.processTransparencyGroup(group);
+        if(!this.currentMarkedContents.isEmpty()) {
+            this.currentMarkedContents.peek().setTransparencyGroup(true);
+        }
+    }
+
+    /**
      * This will process a TextPosition object and add the
      * text to the list of characters on a page.  It takes care of
      * overlapping text.


### PR DESCRIPTION
We try to read text from PDF files but some of the files include extra data that is never shown. These segments are usually grouped in transparency groups. So for us this function to flag a marked content as a transparency group is quite useful.

If there is a way to do this please tell me or if there is a better way to remove text that isn't presented or drawn when the PDF is viewed then I'm all ears.
