### PR TITLE
Changed to the getHeight function for fonts so it will return a more accurate height

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/PDCIDFontType0.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/PDCIDFontType0.java
@@ -392,14 +392,15 @@ public class PDCIDFontType0 extends PDCIDFont
     @Override
     public float getHeight(int code) throws IOException
     {
-        int cid = codeToCID(code);
+        if (glyphHeights.containsKey(code))
+        {
+            return glyphHeights.get(code);
+        }
 
         float height = 0;
-        if (!glyphHeights.containsKey(cid))
-        {
-            height =  (float) getType2CharString(cid).getBounds().getHeight();
-            glyphHeights.put(cid, height);
-        }
+        int cid = codeToCID(code);
+        height =  (float) getType2CharString(cid).getBounds().getHeight();
+        glyphHeights.put(code, height);
         return height;
     }
 

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/PDTrueTypeFont.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/PDTrueTypeFont.java
@@ -151,6 +151,7 @@ public class PDTrueTypeFont extends PDSimpleFont implements PDVectorFont
     private final TrueTypeFont ttf;
     private final boolean isEmbedded;
     private final boolean isDamaged;
+    private final Map<Integer, Float> glyphHeights = new HashMap<Integer, Float>();
 
     /**
      * Creates a new TrueType font from a Font dictionary.
@@ -333,13 +334,43 @@ public class PDTrueTypeFont extends PDSimpleFont implements PDVectorFont
     @Override
     public float getHeight(int code) throws IOException
     {
-        int gid = codeToGID(code);
-        GlyphData glyph = ttf.getGlyph().getGlyph(gid);
-        if (glyph != null)
+        if (glyphHeights.containsKey(code))
         {
-            return glyph.getBoundingBox().getHeight();
+            return glyphHeights.get(code);
         }
-        return 0;
+
+        float height = 0;
+        String name = codeToName(code);
+        int gid = ttf.nameToGID(name);
+        gid = (gid == 0) ? codeToGID(code) : gid;
+
+        GlyphData glyph = ttf.getGlyph().getGlyph(gid);
+        if (glyph == null)
+        {
+            glyphHeights.put(code, height);
+            return height;
+        }
+        if (glyph.getPath() != null)
+        {
+            height = (float) glyph.getPath().getBounds().getHeight();
+        }
+        if (height == 0)
+        {
+            height = (float) glyph.getBoundingBox().getHeight();
+        }
+
+        float unitsPerEM = ttf.getUnitsPerEm();
+        if (unitsPerEM != 1000)
+        {
+            height *= 1000f / unitsPerEM;
+        }
+        glyphHeights.put(code, height);
+        return height;
+    }
+
+    public String codeToName(int code)
+    {
+        return getEncoding().getName(code);
     }
 
     @Override

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/PDType1CFont.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/PDType1CFont.java
@@ -54,7 +54,7 @@ public class PDType1CFont extends PDSimpleFont
 {
     private static final Log LOG = LogFactory.getLog(PDType1CFont.class);
 
-    private final Map<String, Float> glyphHeights = new HashMap<String, Float>();
+    private final Map<Integer, Float> glyphHeights = new HashMap<Integer, Float>();
     private Float avgWidth = null;
     private Matrix fontMatrix;
     private final AffineTransform fontMatrixTransform;
@@ -269,13 +269,18 @@ public class PDType1CFont extends PDSimpleFont
     @Override
     public float getHeight(int code) throws IOException
     {
-        String name = codeToName(code);
-        float height = 0;
-        if (!glyphHeights.containsKey(name))
+        if (glyphHeights.containsKey(code))
         {
-            height = (float)cffFont.getType1CharString(name).getBounds().getHeight(); // todo: cffFont could be null
-            glyphHeights.put(name, height);
+            return glyphHeights.get(code);
         }
+
+        float height = 0;
+        String name = codeToName(code);
+        if (name != null && cffFont != null)
+        {
+            height = (float)cffFont.getType1CharString(name).getBounds().getHeight();
+        }
+        glyphHeights.put(code, height);
         return height;
     }
 

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/PDType1Font.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/PDType1Font.java
@@ -94,6 +94,7 @@ public class PDType1Font extends PDSimpleFont
     private final boolean isDamaged;
     private Matrix fontMatrix;
     private final AffineTransform fontMatrixTransform;
+    private final Map<Integer, Float> glyphHeights = new HashMap<Integer, Float>();
 
     /**
      * Creates a Type 1 standard 14 font for embedding.
@@ -312,17 +313,29 @@ public class PDType1Font extends PDSimpleFont
     @Override
     public float getHeight(int code) throws IOException
     {
-        String name = codeToName(code);
+        if (glyphHeights.containsKey(code))
+        {
+            return glyphHeights.get(code);
+        }
+        float height = 0;
         if (getStandard14AFM() != null)
         {
             String afmName = getEncoding().getName(code);
-            return getStandard14AFM().getCharacterHeight(afmName); // todo: isn't this the y-advance, not the height?
+            height = getStandard14AFM().getCharacterHeight(afmName); // todo: isn't this the y-advance, not the height?
         }
         else
         {
+            String name = codeToName(code);
             // todo: should be scaled by font matrix
-            return (float) genericFont.getPath(name).getBounds().getHeight();
+            height = (float) genericFont.getPath(name).getBounds().getHeight();
+            if(height == 0)
+            {
+                height = genericFont.getFontBBox().getHeight();
+            }
         }
+
+        glyphHeights.put(code, height);
+        return glyphHeights.get(code);
     }
 
     @Override


### PR DESCRIPTION
The getHeight in the fonts gave back approximated heights and in some cases only height the first time the function was called. Tried to clean up the functions and return a more accurate height for each glyph.
