### PR TITLE
Update PDFStreamEngine.java

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/contentstream/PDFStreamEngine.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/contentstream/PDFStreamEngine.java
@@ -470,7 +470,7 @@ public abstract class PDFStreamEngine
             else if (token instanceof Operator)
             {
                 processOperator((Operator) token, arguments);
-                arguments = new ArrayList<COSBase>();
+                arguments = clear();
             }
             else
             {


### PR DESCRIPTION
There's no need to allocate new ArrayList in `processStreamOperators`. In my test case of a `4.2M` pdf, text extraction reduce from 16 seconds to 14 seconds.
