### PR TITLE
Enhanced ImageType to support BufferedImage.TYPE_3BYTE_BGR

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/rendering/ImageType.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/rendering/ImageType.java
@@ -61,6 +61,16 @@ public enum ImageType
         {
             return BufferedImage.TYPE_INT_ARGB;
         }
+    },
+
+    /** Blue, Green, and Red stored in 3 bytes */
+    BGR_3BYTE
+    {
+        @Override
+        int toBufferedImageType()
+        {
+            return BufferedImage.TYPE_3BYTE_BGR;
+        }
     };
 
     abstract int toBufferedImageType();


### PR DESCRIPTION
The application we are developing converts PDF to an image with TYPE_3BYTE_BGR type. We could do it fine with PDFBox 1.8 but after migration to 2.0 we can't specify this type and have to render an image via PDFBox first, then convert that image to desired TYPE_3BYTE_BGR.
