### PR TITLE
Infinite Read Loop

### DIFF
--- a/fontbox/src/main/java/org/apache/fontbox/ttf/BufferedRandomAccessFile.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/BufferedRandomAccessFile.java
@@ -39,12 +39,12 @@ public class BufferedRandomAccessFile extends RandomAccessFile
     private final byte buffer[];
     private int bufend = 0;
     private int bufpos = 0;
-    
+
     /**
      * The position inside the actual file.
      */
     private long realpos = 0;
-    
+
     /**
      * Buffer size.
      */
@@ -165,7 +165,7 @@ public class BufferedRandomAccessFile extends RandomAccessFile
                 leftover += bytesRead;
             }
         }
-        return leftover;
+        return (leftover > 0) ? leftover : -1;
     }
 
     /**

--- a/fontbox/src/test/java/org/apache/fontbox/ttf/BufferedRandomAccessFileTest.java
+++ b/fontbox/src/test/java/org/apache/fontbox/ttf/BufferedRandomAccessFileTest.java
@@ -1,0 +1,38 @@
+package org.apache.fontbox.ttf;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class BufferedRandomAccessFileTest {
+
+    @Test
+    public void ensureReadFinishes() throws IOException {
+
+        final File file = File.createTempFile("apache-pdfbox", ".dat");
+
+        final OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(file));
+        final String content = "1234567890";
+        outputStream.write(content.getBytes("UTF-8"));
+        outputStream.flush();
+        outputStream.close();
+
+        final byte[] readBuffer = new byte[2];
+        final BufferedRandomAccessFile buffer = new BufferedRandomAccessFile(file, "r", 4);
+
+        int amountRead;
+        int totalAmountRead = 0;
+        while ((amountRead = buffer.read(readBuffer, 0, 2)) != -1)
+        {
+            totalAmountRead += amountRead;
+        }
+        Assert.assertEquals(10, totalAmountRead);
+
+    }
+
+}


### PR DESCRIPTION
When reading an input file using the BufferedRandomAccesssFile an infinite loop will occur once the buffer is drained and the value `leftover` becomes 0, since the read method will continue to return 0 as the -1 result from `fillBuffer()` is never propagated upstream and any code that is executing in a loop using -1 as an indicator that the file has been fully read will never exit.

An example of where this occurs can be found here:

https://github.com/apache/pdfbox/blob/782ac20dcea7b2e5bb6848f4da9a68c00b4d69a3/fontbox/src/main/java/org/apache/fontbox/ttf/TTFDataStream.java#L264