### PR TITLE
Support for text positioning 

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDPageContentStream.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDPageContentStream.java
@@ -388,6 +388,13 @@ public final class PDPageContentStream implements Closeable
      */
     public void showText(String text) throws IOException
     {
+        showTextInternal(text);
+        write(" ");
+
+        writeOperator("Tj");
+    }
+
+    private void showTextInternal(String text) throws IOException {
         if (!inTextMode)
         {
             throw new IllegalStateException("Must call beginText() before showText()");
@@ -412,9 +419,29 @@ public final class PDPageContentStream implements Closeable
         }
 
         COSWriter.writeString(font.encode(text), output);
-        write(" ");
+    }
 
-        writeOperator("Tj");
+    public void showTextWithPositioning(Object[] array) throws IOException {
+
+        write("[");
+
+        boolean lastWasNumber = false;
+        for (Object obj : array) {
+            if (obj instanceof String) {
+                showTextInternal((String) obj);
+                lastWasNumber = false;
+            } else {
+                if (lastWasNumber) {
+                    write(" ");
+                } else {
+                    lastWasNumber = true;
+                }
+
+                appendRawCommands((Float) obj);
+            }
+        }
+        write("]TJ");
+        writeLine();
     }
 
     /**


### PR DESCRIPTION
I am trying to implement text justification for UNICODE encoded texts in project https://github.com/danfickle/openhtmltopdf . Because Tw operator is not supported (is ignored) for unicode strings, I need to calculate and write spacing between characters for every single character. 

I implemented TJ text showing operator, which was not supported by PDPageContentStream. 