### PR TITLE
Allow rendering with different X and Y scale

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/rendering/PDFRenderer.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/rendering/PDFRenderer.java
@@ -137,7 +137,7 @@ public class PDFRenderer
         }
         g.clearRect(0, 0, image.getWidth(), image.getHeight());
         
-        transform(g, page, scale);
+        transform(g, page, scale, scale);
 
         // the end-user may provide a custom PageDrawer
         PageDrawerParameters parameters = new PageDrawerParameters(this, page);
@@ -160,6 +160,7 @@ public class PDFRenderer
         renderPageToGraphics(pageIndex, graphics, 1);
     }
 
+
     /**
      * Renders a given page to an AWT Graphics2D instance.
      * @param pageIndex the zero-based index of the page to be converted
@@ -170,10 +171,24 @@ public class PDFRenderer
     public void renderPageToGraphics(int pageIndex, Graphics2D graphics, float scale)
             throws IOException
     {
+    		renderPageToGraphics(pageIndex, graphics, scale, scale);
+    }
+    
+    /**
+     * Renders a given page to an AWT Graphics2D instance.
+     * @param pageIndex the zero-based index of the page to be converted
+     * @param graphics the Graphics2D on which to draw the page
+     * @param scaleX the scale to draw the page at for the x-axis
+     * @param scaleY the scale to draw the page at for the y-axis
+     * @throws IOException if the PDF cannot be read
+     */
+    public void renderPageToGraphics(int pageIndex, Graphics2D graphics, float scaleX, float scaleY)
+            throws IOException
+    {
         PDPage page = document.getPage(pageIndex);
         // TODO need width/wight calculations? should these be in PageDrawer?
 
-        transform(graphics, page, scale);
+        transform(graphics, page, scaleX, scaleY);
 
         PDRectangle cropBox = page.getCropBox();
         graphics.clearRect(0, 0, (int) cropBox.getWidth(), (int) cropBox.getHeight());
@@ -185,9 +200,9 @@ public class PDFRenderer
     }
 
     // scale rotate translate
-    private void transform(Graphics2D graphics, PDPage page, float scale)
+    private void transform(Graphics2D graphics, PDPage page, float scaleX, float scaleY)
     {
-        graphics.scale(scale, scale);
+        graphics.scale(scaleX, scaleY);
 
         // TODO should we be passing the scale to PageDrawer rather than messing with Graphics?
         int rotationAngle = page.getRotation();


### PR DESCRIPTION
Hi,

We need to render pages sometimes with diffent X and Y scales. But currently there is no public method to do so. Please check the pull request which adds support for separate X and Y scale when rendering to a graphics object.