### PR TITLE
PDFBOX-4172: do translation when no PDFormXObject is encountered

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/form/PDAcroForm.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/form/PDAcroForm.java
@@ -712,6 +712,7 @@ public final class PDAcroForm implements COSObjectable
     private boolean resolveNeedsTranslation(PDAppearanceStream appearanceStream)
     {
         boolean needsTranslation = false;
+        boolean foundFormObject = false;
         
         PDResources resources = appearanceStream.getResources();
         if (resources != null && resources.getXObjectNames().iterator().hasNext())
@@ -728,6 +729,7 @@ public final class PDAcroForm implements COSObjectable
                     PDXObject xObject = resources.getXObject(xObjectNames.next());
                     if (xObject instanceof PDFormXObject)
                     {
+                        foundFormObject = true;
                         PDRectangle bbox = ((PDFormXObject)xObject).getBBox();
                         float llX = bbox.getLowerLeftX();
                         float llY = bbox.getLowerLeftY();
@@ -744,7 +746,7 @@ public final class PDAcroForm implements COSObjectable
                     LOG.debug("Couldn't resolve possible need for translation - ignoring, content might be misplaced", e);
                 }
             }
-            return needsTranslation;
+            return needsTranslation || !foundFormObject;
         }
         
         return true;


### PR DESCRIPTION
I've created PDF forms using LibreOffice 5 and for one file, the first
form element will not show up filled when flattening the PDF.

It turns out that resolveNeedsTranslation does not hit a PDFormXObject
and thus returns false, although translation is actually needed.

This patch fixes this by tracking whether any PDFormXObject has been
encountered and returning true when none is seen.

https://issues.apache.org/jira/browse/PDFBOX-4172