### PR TITLE
Refining GSUB system to support new Languages, feature complete Bengali

### DIFF
--- a/fontbox/src/main/java/org/apache/fontbox/ttf/GlyphSubstitutionTable.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/GlyphSubstitutionTable.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.fontbox.ttf.gsub.GlyphSubstitutionDataExtractor;
+import org.apache.fontbox.ttf.model.GsubData;
 import org.apache.fontbox.ttf.table.common.CoverageTable;
 import org.apache.fontbox.ttf.table.common.CoverageTableFormat1;
 import org.apache.fontbox.ttf.table.common.CoverageTableFormat2;
@@ -72,7 +73,7 @@ public class GlyphSubstitutionTable extends TTFTable
 
     private String lastUsedSupportedScript;
 
-    private Map<String, Map<List<Integer>, Integer>> rawGSubData;
+    private GsubData gsubData;
 
     GlyphSubstitutionTable(TrueTypeFont font)
     {
@@ -103,9 +104,8 @@ public class GlyphSubstitutionTable extends TTFTable
 
         GlyphSubstitutionDataExtractor glyphSubstitutionDataExtractor = new GlyphSubstitutionDataExtractor();
 
-        rawGSubData = glyphSubstitutionDataExtractor
+        gsubData = glyphSubstitutionDataExtractor
                 .getGsubData(scriptList, featureListTable, lookupListTable);
-        LOG.debug("rawGSubData: " + rawGSubData);
     }
 
     private Map<String, ScriptTable> readScriptList(TTFDataStream data, long offset)
@@ -670,9 +670,9 @@ public class GlyphSubstitutionTable extends TTFTable
         return gid;
     }
 
-    public Map<String, Map<List<Integer>, Integer>> getRawGSubData()
+    public GsubData getGsubData()
     {
-        return rawGSubData;
+        return gsubData;
     }
 
     private RangeRecord readRangeRecord(TTFDataStream data) throws IOException

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/TrueTypeFont.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/TrueTypeFont.java
@@ -27,11 +27,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.fontbox.FontBoxFont;
-import org.apache.fontbox.util.BoundingBox;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.fontbox.FontBoxFont;
+import org.apache.fontbox.ttf.model.GsubData;
+import org.apache.fontbox.util.BoundingBox;
 
 /**
  * A TrueType font file.
@@ -654,15 +655,15 @@ public class TrueTypeFont implements FontBoxFont, Closeable
         return 0;
     }
 
-    public Map<String, Map<List<Integer>, Integer>> getGlyphSubstitutionMap() throws IOException
+    public GsubData getGsubData() throws IOException
     {
         GlyphSubstitutionTable table = getGsub();
         if (table == null)
         {
-            return Collections.emptyMap();
+            return GsubData.NO_DATA_FOUND;
         }
 
-        return table.getRawGSubData();
+        return table.getGsubData();
     }
 
     /**

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/gsub/GsubWorker.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/gsub/GsubWorker.java
@@ -28,6 +28,11 @@ import java.util.List;
  */
 public interface GsubWorker
 {
-    List<Integer> preProcessAndApplyGsubTransfs(List<Integer> originalGlyphIds);
+    /**
+     * Applis language-specific transforms including GSUB and any other pre or post-processing necessary for displaying
+     * Glyphs correctly.
+     * 
+     */
+    List<Integer> applyTransforms(List<Integer> originalGlyphIds);
 
 }

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/gsub/GsubWorker.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/gsub/GsubWorker.java
@@ -28,8 +28,6 @@ import java.util.List;
  */
 public interface GsubWorker
 {
-    List<Integer> substituteGlyphs(List<Integer> originalGlyphIds);
-
-    List<Integer> repositionGlyphs(List<Integer> originalGlyphIds);
+    List<Integer> preProcessAndApplyGsubTransfs(List<Integer> originalGlyphIds);
 
 }

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/gsub/GsubWorker.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/gsub/GsubWorker.java
@@ -29,7 +29,7 @@ import java.util.List;
 public interface GsubWorker
 {
     /**
-     * Applis language-specific transforms including GSUB and any other pre or post-processing necessary for displaying
+     * Applies language-specific transforms including GSUB and any other pre or post-processing necessary for displaying
      * Glyphs correctly.
      * 
      */

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/gsub/GsubWorkerFactory.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/gsub/GsubWorkerFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fontbox.ttf.gsub;
+
+import org.apache.fontbox.ttf.CmapLookup;
+import org.apache.fontbox.ttf.model.GsubData;
+import org.apache.fontbox.ttf.model.Language;
+
+/**
+ * Gets a {@link Language} specific instance of a {@link GsubWorker}
+ * 
+ * @author Palash Ray
+ *
+ */
+public class GsubWorkerFactory
+{
+
+    public GsubWorker getGsubWorker(CmapLookup cmapLookup, GsubData gsubData)
+    {
+        switch (gsubData.getLanguage())
+        {
+        case BENGALI:
+            return new GsubWorkerForBengali(cmapLookup, gsubData);
+        default:
+            throw new UnsupportedOperationException(
+                    "The language " + gsubData.getLanguage() + " is not yet supported");
+        }
+
+    }
+
+}

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/gsub/GsubWorkerForBengali.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/gsub/GsubWorkerForBengali.java
@@ -54,7 +54,7 @@ public class GsubWorkerForBengali implements GsubWorker
 
     private final List<Integer> beforeHalfGlyphIds;
 
-    public GsubWorkerForBengali(CmapLookup cmapLookup, GsubData gsubData)
+    GsubWorkerForBengali(CmapLookup cmapLookup, GsubData gsubData)
     {
         this.gsubData = gsubData;
         beforeHalfGlyphIds = getBeforeHalfGlyphIds(cmapLookup);

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/gsub/GsubWorkerForBengali.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/gsub/GsubWorkerForBengali.java
@@ -73,7 +73,7 @@ public class GsubWorkerForBengali implements GsubWorker
     }
 
     @Override
-    public List<Integer> preProcessAndApplyGsubTransfs(List<Integer> originalGlyphIds)
+    public List<Integer> applyTransforms(List<Integer> originalGlyphIds)
     {
         List<Integer> intermediateGlyphsFromGsub = originalGlyphIds;
 

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/model/GsubData.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/model/GsubData.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fontbox.ttf.model;
+
+import java.util.Set;
+
+/**
+ * Model for data from the GSUB tables
+ * 
+ * @author Palash Ray
+ *
+ */
+public interface GsubData
+{
+    /**
+     * To be used when there is no GSUB data available
+     */
+    GsubData NO_DATA_FOUND = new GsubData()
+    {
+
+        @Override
+        public boolean isFeatureSupported(String featureName)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Language getLanguage()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ScriptFeature getFeature(String featureName)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getActiveScriptName()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Set<String> getSupportedFeatures()
+        {
+            throw new UnsupportedOperationException();
+        }
+    };
+
+    Language getLanguage();
+
+    /**
+     * A {@link Language} can have more than one script that is supported. However, at any given point, only one of the
+     * many scripts are active. This method returns the name of the script that is active.
+     */
+    String getActiveScriptName();
+
+    boolean isFeatureSupported(String featureName);
+
+    ScriptFeature getFeature(String featureName);
+
+    Set<String> getSupportedFeatures();
+
+}

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/model/Language.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/model/Language.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fontbox.ttf.model;
+
+import org.apache.fontbox.ttf.table.common.ScriptRecord;
+
+/**
+ * Enumerates the languages supported for GSUB operation
+ * 
+ * @author Palash Ray
+ *
+ */
+public enum Language
+{
+
+    BENGALI(new String[] { "bng2", "beng" });
+
+    private final String[] scriptNames;
+
+    private Language(String[] scriptNames)
+    {
+        this.scriptNames = scriptNames;
+    }
+
+    /**
+     * ScriptNames form the basis of identification of the language. This method gets the ScriptNames that the given
+     * Language supports, in the order of preference, Index 0 being the most preferred. These names should match the
+     * {@link ScriptRecord} in the GSUB system.
+     */
+    public String[] getScriptNames()
+    {
+        return scriptNames;
+    }
+
+}

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/model/Language.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/model/Language.java
@@ -17,10 +17,14 @@
 
 package org.apache.fontbox.ttf.model;
 
+import org.apache.fontbox.ttf.gsub.GsubWorker;
+import org.apache.fontbox.ttf.gsub.GsubWorkerFactory;
 import org.apache.fontbox.ttf.table.common.ScriptRecord;
 
 /**
- * Enumerates the languages supported for GSUB operation
+ * Enumerates the languages supported for GSUB operation. In order to support a new language, you need to add it here
+ * and then implement the {@link GsubWorker} for the given language and return the same from the
+ * {@link GsubWorkerFactory#getGsubWorker(org.apache.fontbox.ttf.CmapLookup, GsubData)}
  * 
  * @author Palash Ray
  *

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/model/MapBackedGsubData.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/model/MapBackedGsubData.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fontbox.ttf.model;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 
+ * A {@link Map} based simple implementation of the {@link GsubData}
+ * 
+ * @author Palash Ray
+ *
+ */
+public class MapBackedGsubData implements GsubData
+{
+
+    private final Language language;
+    private final String activeScriptName;
+    private final Map<String, Map<List<Integer>, Integer>> glyphSubstitutionMap;
+
+    public MapBackedGsubData(Language language, String activeScriptName,
+            Map<String, Map<List<Integer>, Integer>> glyphSubstitutionMap)
+    {
+        this.language = language;
+        this.activeScriptName = activeScriptName;
+        this.glyphSubstitutionMap = glyphSubstitutionMap;
+    }
+
+    @Override
+    public Language getLanguage()
+    {
+        return language;
+    }
+
+    @Override
+    public String getActiveScriptName()
+    {
+        return activeScriptName;
+    }
+
+    @Override
+    public boolean isFeatureSupported(String featureName)
+    {
+        return glyphSubstitutionMap.containsKey(featureName);
+    }
+
+    @Override
+    public ScriptFeature getFeature(String featureName)
+    {
+        if (!isFeatureSupported(featureName))
+        {
+            throw new UnsupportedOperationException(
+                    "The feature " + featureName + " is not supported!");
+        }
+
+        return new MapBackedScriptFeature(featureName, glyphSubstitutionMap.get(featureName));
+    }
+
+    @Override
+    public Set<String> getSupportedFeatures()
+    {
+        return glyphSubstitutionMap.keySet();
+    }
+
+}

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/model/MapBackedScriptFeature.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/model/MapBackedScriptFeature.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fontbox.ttf.model;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 
+ * A {@link Map} based simple implementation of the {@link ScriptFeature}
+ * 
+ * @author Palash Ray
+ *
+ */
+public class MapBackedScriptFeature implements ScriptFeature
+{
+
+    private final String name;
+    private final Map<List<Integer>, Integer> featureMap;
+
+    public MapBackedScriptFeature(String name, Map<List<Integer>, Integer> featureMap)
+    {
+        this.name = name;
+        this.featureMap = featureMap;
+    }
+
+    @Override
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public Set<List<Integer>> getAllGlyphIdsForSubstitution()
+    {
+        return featureMap.keySet();
+    }
+
+    @Override
+    public boolean canReplaceGlyphs(List<Integer> glyphIds)
+    {
+        return featureMap.containsKey(glyphIds);
+    }
+
+    @Override
+    public Integer getReplacementForGlyphs(List<Integer> glyphIds)
+    {
+        if (!canReplaceGlyphs(glyphIds))
+        {
+            throw new UnsupportedOperationException(
+                    "The glyphs " + glyphIds + " cannot be replaced");
+        }
+        return featureMap.get(glyphIds);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((featureMap == null) ? 0 : featureMap.hashCode());
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        MapBackedScriptFeature other = (MapBackedScriptFeature) obj;
+        if (featureMap == null)
+        {
+            if (other.featureMap != null)
+                return false;
+        }
+        else if (!featureMap.equals(other.featureMap))
+            return false;
+        if (name == null)
+        {
+            if (other.name != null)
+                return false;
+        }
+        else if (!name.equals(other.name))
+            return false;
+        return true;
+    }
+
+}

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/model/ScriptFeature.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/model/ScriptFeature.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fontbox.ttf.model;
+
+import java.util.List;
+import java.util.Set;
+
+import org.apache.fontbox.ttf.table.common.FeatureRecord;
+
+/**
+ * Models a {@link FeatureRecord}
+ * 
+ * @author Palash Ray
+ *
+ */
+public interface ScriptFeature
+{
+
+    String getName();
+
+    Set<List<Integer>> getAllGlyphIdsForSubstitution();
+
+    boolean canReplaceGlyphs(List<Integer> glyphIds);
+
+    Integer getReplacementForGlyphs(List<Integer> glyphIds);
+
+}

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/model/package.html
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/model/package.html
@@ -1,0 +1,25 @@
+<!--
+ ! Licensed to the Apache Software Foundation (ASF) under one or more
+ ! contributor license agreements.  See the NOTICE file distributed with
+ ! this work for additional information regarding copyright ownership.
+ ! The ASF licenses this file to You under the Apache License, Version 2.0
+ ! (the "License"); you may not use this file except in compliance with
+ ! the License.  You may obtain a copy of the License at
+ !
+ !      http://www.apache.org/licenses/LICENSE-2.0
+ !
+ ! Unless required by applicable law or agreed to in writing, software
+ ! distributed under the License is distributed on an "AS IS" BASIS,
+ ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ! See the License for the specific language governing permissions and
+ ! limitations under the License.
+ !-->
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<html>
+<head>
+
+</head>
+<body>
+This package contains a more logical model for the various font tables like GSUB.
+</body>
+</html>

--- a/fontbox/src/test/java/org/apache/fontbox/ttf/GlyphSubstitutionTableTest.java
+++ b/fontbox/src/test/java/org/apache/fontbox/ttf/GlyphSubstitutionTableTest.java
@@ -46,7 +46,7 @@ public class GlyphSubstitutionTableTest
             "blwf", "blws", "half", "haln", "init", "nukt", "pres", "pstf", "rphf", "vatu");
 
     @Test
-    public void testGetRawGSubData() throws IOException
+    public void testGetGsubData() throws IOException
     {
         // given
         MemoryTTFDataStream memoryTTFDataStream = new MemoryTTFDataStream(

--- a/fontbox/src/test/java/org/apache/fontbox/ttf/GlyphSubstitutionTableTest.java
+++ b/fontbox/src/test/java/org/apache/fontbox/ttf/GlyphSubstitutionTableTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.fontbox.ttf.model.GsubData;
+import org.apache.fontbox.ttf.model.Language;
 import org.apache.fontbox.ttf.model.MapBackedScriptFeature;
 import org.apache.fontbox.ttf.model.ScriptFeature;
 import org.junit.Test;
@@ -58,11 +59,13 @@ public class GlyphSubstitutionTableTest
         testClass.read(null, memoryTTFDataStream);
 
         // then
-        GsubData rawGsubData = testClass.getGsubData();
-        assertNotNull(rawGsubData);
-        assertNotEquals(GsubData.NO_DATA_FOUND, rawGsubData);
+        GsubData gsubData = testClass.getGsubData();
+        assertNotNull(gsubData);
+        assertNotEquals(GsubData.NO_DATA_FOUND, gsubData);
+        assertEquals(Language.BENGALI, gsubData.getLanguage());
+        assertEquals("bng2", gsubData.getActiveScriptName());
 
-        assertEquals(new HashSet<>(EXPECTED_FEATURE_NAMES), rawGsubData.getSupportedFeatures());
+        assertEquals(new HashSet<>(EXPECTED_FEATURE_NAMES), gsubData.getSupportedFeatures());
 
         String templatePathToFile = "/gsub/lohit_bengali/bng2/%s.txt";
 
@@ -73,7 +76,7 @@ public class GlyphSubstitutionTableTest
                     String.format(templatePathToFile, featureName));
             ScriptFeature scriptFeature = new MapBackedScriptFeature(featureName,
                     expectedGsubTableRawData);
-            assertEquals(scriptFeature, rawGsubData.getFeature(featureName));
+            assertEquals(scriptFeature, gsubData.getFeature(featureName));
         }
 
     }

--- a/fontbox/src/test/java/org/apache/fontbox/ttf/GlyphSubstitutionTableTest.java
+++ b/fontbox/src/test/java/org/apache/fontbox/ttf/GlyphSubstitutionTableTest.java
@@ -17,7 +17,7 @@
 package org.apache.fontbox.ttf;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.BufferedReader;
@@ -30,8 +30,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
+import org.apache.fontbox.ttf.model.GsubData;
+import org.apache.fontbox.ttf.model.MapBackedScriptFeature;
+import org.apache.fontbox.ttf.model.ScriptFeature;
 import org.junit.Test;
 
 public class GlyphSubstitutionTableTest
@@ -56,12 +58,11 @@ public class GlyphSubstitutionTableTest
         testClass.read(null, memoryTTFDataStream);
 
         // then
-        Map<String, Map<List<Integer>, Integer>> rawGsubData = testClass.getRawGSubData();
+        GsubData rawGsubData = testClass.getGsubData();
         assertNotNull(rawGsubData);
-        assertFalse(rawGsubData.isEmpty());
+        assertNotEquals(GsubData.NO_DATA_FOUND, rawGsubData);
 
-        Set<String> featureNames = rawGsubData.keySet();
-        assertEquals(new HashSet<>(EXPECTED_FEATURE_NAMES), featureNames);
+        assertEquals(new HashSet<>(EXPECTED_FEATURE_NAMES), rawGsubData.getSupportedFeatures());
 
         String templatePathToFile = "/gsub/lohit_bengali/bng2/%s.txt";
 
@@ -70,7 +71,9 @@ public class GlyphSubstitutionTableTest
             System.out.println("******* Testing feature: " + featureName);
             Map<List<Integer>, Integer> expectedGsubTableRawData = getExpectedGsubTableRawData(
                     String.format(templatePathToFile, featureName));
-            assertEquals(expectedGsubTableRawData, rawGsubData.get(featureName));
+            ScriptFeature scriptFeature = new MapBackedScriptFeature(featureName,
+                    expectedGsubTableRawData);
+            assertEquals(scriptFeature, rawGsubData.getFeature(featureName));
         }
 
     }

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDPageContentStream.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDPageContentStream.java
@@ -1226,7 +1226,7 @@ public final class PDPageContentStream extends PDAbstractContentStream implement
         GsubWorker gsubWorker = gsubWorkerFactory.getGsubWorker(cmapLookup, gsubData);
 
         List<Integer> glyphIdsAfterGsub = gsubWorker
-                .preProcessAndApplyGsubTransfs(originalGlyphIds);
+                .applyTransforms(originalGlyphIds);
 
         for (Integer glyphId : glyphIdsAfterGsub)
         {

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDPageContentStream.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDPageContentStream.java
@@ -1225,8 +1225,8 @@ public final class PDPageContentStream extends PDAbstractContentStream implement
 
         GsubWorker gsubWorker = gsubWorkerFactory.getGsubWorker(cmapLookup, gsubData);
 
-        List<Integer> repositionedGlyphIds = gsubWorker.repositionGlyphs(originalGlyphIds);
-        List<Integer> glyphIdsAfterGsub = gsubWorker.substituteGlyphs(repositionedGlyphIds);
+        List<Integer> glyphIdsAfterGsub = gsubWorker
+                .preProcessAndApplyGsubTransfs(originalGlyphIds);
 
         for (Integer glyphId : glyphIdsAfterGsub)
         {

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDPageContentStream.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDPageContentStream.java
@@ -34,7 +34,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.fontbox.ttf.CmapLookup;
 import org.apache.fontbox.ttf.gsub.CompoundCharacterTokenizer;
 import org.apache.fontbox.ttf.gsub.GsubWorker;
-import org.apache.fontbox.ttf.gsub.GsubWorkerForBengali;
+import org.apache.fontbox.ttf.gsub.GsubWorkerFactory;
 import org.apache.fontbox.ttf.model.GsubData;
 import org.apache.pdfbox.contentstream.PDAbstractContentStream;
 import org.apache.pdfbox.cos.COSArray;
@@ -1221,8 +1221,9 @@ public final class PDPageContentStream extends PDAbstractContentStream implement
             originalGlyphIds.add(glyphId);
         }
 
-        // TODO: figure out how to get this language-specific detail up here
-        GsubWorker gsubWorker = new GsubWorkerForBengali(cmapLookup, gsubData);
+        GsubWorkerFactory gsubWorkerFactory = new GsubWorkerFactory();
+
+        GsubWorker gsubWorker = gsubWorkerFactory.getGsubWorker(cmapLookup, gsubData);
 
         List<Integer> repositionedGlyphIds = gsubWorker.repositionGlyphs(originalGlyphIds);
         List<Integer> glyphIdsAfterGsub = gsubWorker.substituteGlyphs(repositionedGlyphIds);

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDPageContentStream.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDPageContentStream.java
@@ -25,7 +25,6 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
 import java.util.regex.Pattern;
@@ -36,6 +35,7 @@ import org.apache.fontbox.ttf.CmapLookup;
 import org.apache.fontbox.ttf.gsub.CompoundCharacterTokenizer;
 import org.apache.fontbox.ttf.gsub.GsubWorker;
 import org.apache.fontbox.ttf.gsub.GsubWorkerForBengali;
+import org.apache.fontbox.ttf.model.GsubData;
 import org.apache.pdfbox.contentstream.PDAbstractContentStream;
 import org.apache.pdfbox.cos.COSArray;
 import org.apache.pdfbox.cos.COSBase;
@@ -330,12 +330,11 @@ public final class PDPageContentStream extends PDAbstractContentStream implement
         if (font instanceof PDType0Font)
         {
             PDType0Font pdType0Font = (PDType0Font) font;
-            Map<String, Map<List<Integer>, Integer>> glyphSubstitutionMap = pdType0Font
-                    .getGlyphSubstitutionMap();
-            if (!glyphSubstitutionMap.isEmpty())
+            GsubData gsubData = pdType0Font.getGsubData();
+            if (gsubData != GsubData.NO_DATA_FOUND)
             {
                 Set<Integer> glyphIds = new HashSet<>();
-                encodedText = encodeForGsub(glyphSubstitutionMap, glyphIds, pdType0Font, text);
+                encodedText = encodeForGsub(gsubData, glyphIds, pdType0Font, text);
                 if (pdType0Font.willBeSubset())
                 {
                     pdType0Font.addGlyphsToSubset(glyphIds);
@@ -1177,7 +1176,7 @@ public final class PDPageContentStream extends PDAbstractContentStream implement
         writeOperator("Ts");
     }
 
-    private byte[] encodeForGsub(Map<String, Map<List<Integer>, Integer>> glyphSubstitutionMap,
+    private byte[] encodeForGsub(GsubData gsubData,
             Set<Integer> glyphIds, PDType0Font font, String text) throws IOException
     {
 
@@ -1197,7 +1196,7 @@ public final class PDPageContentStream extends PDAbstractContentStream implement
             }
             else
             {
-                glyphIds.addAll(applyGSUBRules(out, font, glyphSubstitutionMap, word));
+                glyphIds.addAll(applyGSUBRules(out, font, gsubData, word));
             }
         }
 
@@ -1205,8 +1204,7 @@ public final class PDPageContentStream extends PDAbstractContentStream implement
     }
 
     private List<Integer> applyGSUBRules(ByteArrayOutputStream out, PDType0Font font,
-            Map<String, Map<List<Integer>, Integer>> glyphSubstitutionMap, String word)
-            throws IOException
+            GsubData gsubData, String word) throws IOException
     {
         List<Integer> originalGlyphIds = new ArrayList<>();
         CmapLookup cmapLookup = font.getCmapLookup();
@@ -1224,7 +1222,7 @@ public final class PDPageContentStream extends PDAbstractContentStream implement
         }
 
         // TODO: figure out how to get this language-specific detail up here
-        GsubWorker gsubWorker = new GsubWorkerForBengali(cmapLookup, glyphSubstitutionMap);
+        GsubWorker gsubWorker = new GsubWorkerForBengali(cmapLookup, gsubData);
 
         List<Integer> repositionedGlyphIds = gsubWorker.repositionGlyphs(originalGlyphIds);
         List<Integer> glyphIdsAfterGsub = gsubWorker.substituteGlyphs(repositionedGlyphIds);

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/PDType0Font.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/PDType0Font.java
@@ -20,10 +20,7 @@ import java.awt.geom.GeneralPath;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.logging.Log;
@@ -32,6 +29,7 @@ import org.apache.fontbox.cmap.CMap;
 import org.apache.fontbox.ttf.CmapLookup;
 import org.apache.fontbox.ttf.TTFParser;
 import org.apache.fontbox.ttf.TrueTypeFont;
+import org.apache.fontbox.ttf.model.GsubData;
 import org.apache.fontbox.util.BoundingBox;
 import org.apache.pdfbox.cos.COSArray;
 import org.apache.pdfbox.cos.COSBase;
@@ -52,7 +50,7 @@ public class PDType0Font extends PDFont implements PDVectorFont
 
     private final PDCIDFont descendantFont;
     private final Set<Integer> noUnicode = new HashSet<>(); 
-    private final Map<String, Map<List<Integer>, Integer>> glyphSubstitutionMap;
+    private final GsubData gsubData;
     private final CmapLookup cmapLookup;
     private CMap cMap, cMapUCS2;
     private boolean isCMapPredefined;
@@ -70,7 +68,7 @@ public class PDType0Font extends PDFont implements PDVectorFont
     {
         super(fontDictionary);
 
-        glyphSubstitutionMap = Collections.emptyMap();
+        gsubData = GsubData.NO_DATA_FOUND;
         cmapLookup = null;
 
         COSBase base = dict.getDictionaryObject(COSName.DESCENDANT_FONTS);
@@ -104,7 +102,7 @@ public class PDType0Font extends PDFont implements PDVectorFont
             ttf.enableVerticalSubstitutions();
         }
 
-        glyphSubstitutionMap = ttf.getGlyphSubstitutionMap();
+        gsubData = ttf.getGsubData();
         cmapLookup = ttf.getUnicodeCmapLookup();
 
         embedder = new PDCIDFontType2Embedder(document, dict, ttf, embedSubset, this, vertical);
@@ -599,9 +597,9 @@ public class PDType0Font extends PDFont implements PDVectorFont
         return descendantFont.hasGlyph(code);
     }
 
-    public Map<String, Map<List<Integer>, Integer>> getGlyphSubstitutionMap()
+    public GsubData getGsubData()
     {
-        return glyphSubstitutionMap;
+        return gsubData;
     }
 
     public byte[] encodeGlyphId(int glyphId)


### PR DESCRIPTION
This change set contains some refinement to the code so that GSUB can be supported for any languages with ease. As mentioned in the javadoc for Language enum:
In order to support a new language, you need to add it here and then implement the GsubWorker for the given language and return the same from the GsubWorkerFactory.getGsubWorker(org.apache.fontbox.ttf.CmapLookup, GsubData).

This change set also contains final changes to make Bengali feature complete.

Thanks,
Palash.