### PR TITLE
minor fix: get gsubWoker from map with font as the key

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDPageContentStream.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDPageContentStream.java
@@ -347,7 +347,7 @@ public final class PDPageContentStream extends PDAbstractContentStream implement
         if (font instanceof PDType0Font)
         {
 
-            GsubWorker gsubWorker = gsubWorkers.get(font.getName());
+            GsubWorker gsubWorker = gsubWorkers.get(font);
             if (gsubWorker != null)
             {
                 PDType0Font pdType0Font = (PDType0Font) font;


### PR DESCRIPTION
minor fix: get gsubWoker from map with font as the key