### PR TITLE
Change log level for 'Expected number, actual=COSFloat' message

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdfparser/BaseParser.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdfparser/BaseParser.java
@@ -165,12 +165,12 @@ public abstract class BaseParser
         readExpectedChar('R');
         if (!(value instanceof COSInteger))
         {
-            LOG.error("expected number, actual=" + value + " at offset " + numOffset);
+            LOG.warn("expected number, actual=" + value + " at offset " + numOffset);
             return COSNull.NULL;
         }
         if (!(generationNumber instanceof COSInteger))
         {
-            LOG.error("expected number, actual=" + value + " at offset " + genOffset);
+            LOG.warn("expected number, actual=" + value + " at offset " + genOffset);
             return COSNull.NULL;
         }
         COSObjectKey key = new COSObjectKey(((COSInteger) value).longValue(),


### PR DESCRIPTION
It is a bit misleading to log this as an error since this condition doesn't halt or prevent the parser from continuing.