### PR TITLE
PDFBOX-4080 Optimize memory consumption PDLinkAppearanceHandler

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/annotation/PDAnnotation.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/annotation/PDAnnotation.java
@@ -27,6 +27,7 @@ import org.apache.pdfbox.cos.COSDictionary;
 import org.apache.pdfbox.cos.COSInteger;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.cos.COSNumber;
+import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.common.COSObjectable;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
@@ -818,6 +819,10 @@ public abstract class PDAnnotation implements COSObjectable
      * 
      */
     public void constructAppearances()
+    {
+    }
+
+    public void constructAppearances(PDDocument document)
     {
     }
 

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/annotation/PDAnnotationLink.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/annotation/PDAnnotationLink.java
@@ -22,6 +22,7 @@ import org.apache.pdfbox.cos.COSArray;
 import org.apache.pdfbox.cos.COSBase;
 import org.apache.pdfbox.cos.COSDictionary;
 import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.interactive.action.PDActionFactory;
 import org.apache.pdfbox.pdmodel.interactive.action.PDAction;
 import org.apache.pdfbox.pdmodel.interactive.action.PDActionURI;
@@ -242,13 +243,18 @@ public class PDAnnotationLink extends PDAnnotation
     {
         customAppearanceHandler = appearanceHandler;
     }
+
+    @Override
+    public void constructAppearances(){
+        this.constructAppearances(null);
+    }
     
     @Override
-    public void constructAppearances()
+    public void constructAppearances(PDDocument document)
     {
         if (customAppearanceHandler == null)
         {
-            PDLinkAppearanceHandler appearanceHandler = new PDLinkAppearanceHandler(this);
+            PDLinkAppearanceHandler appearanceHandler = new PDLinkAppearanceHandler(this, document);
             appearanceHandler.generateAppearanceStreams();
         }
         else

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/annotation/handlers/PDAbstractAppearanceHandler.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/annotation/handlers/PDAbstractAppearanceHandler.java
@@ -17,24 +17,21 @@
 
 package org.apache.pdfbox.pdmodel.interactive.annotation.handlers;
 
+import org.apache.pdfbox.cos.COSDictionary;
+import org.apache.pdfbox.cos.COSStream;
+import org.apache.pdfbox.pdmodel.PDAppearanceContentStream;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDResources;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.graphics.color.PDColor;
+import org.apache.pdfbox.pdmodel.graphics.state.PDExtendedGraphicsState;
+import org.apache.pdfbox.pdmodel.interactive.annotation.*;
+
 import java.awt.geom.AffineTransform;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-
-import org.apache.pdfbox.cos.COSStream;
-import org.apache.pdfbox.pdmodel.PDResources;
-import org.apache.pdfbox.pdmodel.common.PDRectangle;
-import org.apache.pdfbox.pdmodel.graphics.color.PDColor;
-import org.apache.pdfbox.pdmodel.graphics.state.PDExtendedGraphicsState;
-import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotation;
-import org.apache.pdfbox.pdmodel.PDAppearanceContentStream;
-import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationLine;
-import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationSquareCircle;
-import org.apache.pdfbox.pdmodel.interactive.annotation.PDAppearanceDictionary;
-import org.apache.pdfbox.pdmodel.interactive.annotation.PDAppearanceEntry;
-import org.apache.pdfbox.pdmodel.interactive.annotation.PDAppearanceStream;
 
 /**
  * Generic handler to generate the fields appearance.
@@ -63,10 +60,17 @@ public abstract class PDAbstractAppearanceHandler implements PDAppearanceHandler
      * Line ending styles where the shape changes its angle, e.g. arrows.
      */
     protected static final Set<String> ANGLED_STYLES = createAngledStyles();
+    protected PDDocument document;
 
     public PDAbstractAppearanceHandler(PDAnnotation annotation)
     {
+        this(annotation,null);
+    }
+
+    public PDAbstractAppearanceHandler(PDAnnotation annotation, PDDocument document)
+    {
         this.annotation = annotation;
+        this.document = document;
     }
 
     @Override
@@ -161,12 +165,15 @@ public abstract class PDAbstractAppearanceHandler implements PDAppearanceHandler
 
         if (downAppearanceEntry.isSubDictionary())
         {
-            //TODO replace with "document.getDocument().createCOSStream()" 
-            downAppearanceEntry = new PDAppearanceEntry(new COSStream());
+            downAppearanceEntry = new PDAppearanceEntry(getDictionary());
             appearanceDictionary.setDownAppearance(downAppearanceEntry);
         }
 
         return downAppearanceEntry;
+    }
+
+    protected COSDictionary getDictionary() {
+        return document == null ? new COSStream() : document.getDocument().createCOSStream();
     }
 
     /**
@@ -185,9 +192,7 @@ public abstract class PDAbstractAppearanceHandler implements PDAppearanceHandler
 
         if (rolloverAppearanceEntry.isSubDictionary())
         {
-            //TODO replace with "document.getDocument().createCOSStream()" 
-            rolloverAppearanceEntry = new PDAppearanceEntry(new COSStream());
-            appearanceDictionary.setRolloverAppearance(rolloverAppearanceEntry);
+            rolloverAppearanceEntry = new PDAppearanceEntry(getDictionary());
         }
 
         return rolloverAppearanceEntry;
@@ -465,8 +470,7 @@ public abstract class PDAbstractAppearanceHandler implements PDAppearanceHandler
 
         if (normalAppearanceEntry == null || normalAppearanceEntry.isSubDictionary())
         {
-            //TODO replace with "document.getDocument().createCOSStream()" 
-            normalAppearanceEntry = new PDAppearanceEntry(new COSStream());
+            normalAppearanceEntry = new PDAppearanceEntry(getDictionary());
             appearanceDictionary.setNormalAppearance(normalAppearanceEntry);
         }
 

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/annotation/handlers/PDLinkAppearanceHandler.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/annotation/handlers/PDLinkAppearanceHandler.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.pdfbox.cos.COSArray;
 import org.apache.pdfbox.cos.COSBase;
 import org.apache.pdfbox.cos.COSNumber;
+import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.graphics.color.PDColor;
 import org.apache.pdfbox.pdmodel.graphics.color.PDDeviceGray;
@@ -42,9 +43,16 @@ public class PDLinkAppearanceHandler extends PDAbstractAppearanceHandler
     
     public PDLinkAppearanceHandler(PDAnnotation annotation)
     {
-        super(annotation);
+        this(annotation, null);
     }
-    
+
+
+    public PDLinkAppearanceHandler(PDAnnotation annotation, PDDocument document)
+    {
+        super(annotation);
+        this.document = document;
+    }
+
     @Override
     public void generateAppearanceStreams()
     {

--- a/pdfbox/src/main/java/org/apache/pdfbox/rendering/PageDrawer.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/rendering/PageDrawer.java
@@ -1300,7 +1300,7 @@ public class PageDrawer extends PDFGraphicsStreamEngine
         if (appearance == null || appearance.getNormalAppearance() == null)
         {
             // TODO: Improve memory consumption by passing a ScratchFile
-            annotation.constructAppearances();
+            annotation.constructAppearances(renderer.document);
         }
         if (annotation.isNoRotate() && getCurrentPage().getRotation() != 0)
         {


### PR DESCRIPTION
A very naive try to solve the [PDFBOX-4080](https://issues.apache.org/jira/browse/PDFBOX-4080)  problem. Works at least for PDAnnotationLink.