### PR TITLE
"Iterator.next()" methods should throw "NoSuchElementException"

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDPageTree.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDPageTree.java
@@ -18,6 +18,7 @@ package org.apache.pdfbox.pdmodel;
 
 import java.util.ArrayDeque;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 import java.util.Queue;
 import org.apache.pdfbox.cos.COSArray;
 import org.apache.pdfbox.cos.COSBase;
@@ -200,6 +201,9 @@ public class PDPageTree implements COSObjectable, Iterable<PDPage>
         @Override
         public PDPage next()
         {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
             COSDictionary next = queue.poll();
             
             sanitizeType(next);

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/documentnavigation/outline/PDOutlineItemIterator.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/documentnavigation/outline/PDOutlineItemIterator.java
@@ -45,6 +45,9 @@ class PDOutlineItemIterator implements Iterator<PDOutlineItem>
     @Override
     public PDOutlineItem next()
     {
+        if (!hasNext()) {
+            throw new java.util.NoSuchElementException();
+        }
         if (currentItem == null)
         {
             currentItem = startingItem;

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/documentnavigation/outline/PDOutlineItemIterator.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/documentnavigation/outline/PDOutlineItemIterator.java
@@ -17,6 +17,7 @@
 package org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline;
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 /**
  * Iterator over the linked list of {@link PDOutlineItem} siblings.
@@ -46,7 +47,7 @@ class PDOutlineItemIterator implements Iterator<PDOutlineItem>
     public PDOutlineItem next()
     {
         if (!hasNext()) {
-            throw new java.util.NoSuchElementException();
+            throw new NoSuchElementException();
         }
         if (currentItem == null)
         {


### PR DESCRIPTION
This fixes 2 Sonarqube violations of rule S2272:
https://rules.sonarsource.com/java/RSPEC-2272

Sonarcloud violation URL:
https://sonarcloud.io/organizations/apache/issues?languages=java&open=AW5JmA2vaYfGX6JOkPBy&resolved=false&rules=squid%3AS2272&types=BUG

Jira ticket:
https://issues.apache.org/jira/browse/PDFBOX-4687