### PR TITLE
"BigDecimal(double)" should not be used

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/rendering/TilingPaint.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/rendering/TilingPaint.java
@@ -186,7 +186,7 @@ class TilingPaint implements Paint
      */
     private static int ceiling(double num)
     {
-        BigDecimal decimal = new BigDecimal(num);
+        BigDecimal decimal = BigDecimal.valueOf(num);
         decimal = decimal.setScale(5, RoundingMode.CEILING); // 5 decimal places of accuracy
         return decimal.intValue();
     }


### PR DESCRIPTION
This fixes 1 Sonarqube violation of rule S2111:
https://rules.sonarsource.com/java/RSPEC-2111

Sonarcloud violation URL:
https://sonarcloud.io/project/issues?id=pdfbox-reactor&languages=java&open=AW5JmBDiaYfGX6JOkPF1&resolved=false&rules=squid%3AS2111&types=BUG

Jira ticket:
https://issues.apache.org/jira/browse/PDFBOX-4688