### PR TITLE
PDFBOX-5002: fix word detection in PDFTextStripper

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/text/PDFTextStripper.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/text/PDFTextStripper.java
@@ -686,6 +686,17 @@ public class PDFTextStripper extends LegacyPDFStreamEngine
                     {
                         line.add(LineItem.getWordSeparator());
                     }
+                    // if there are too many spaces between last character and current, reset the max line height as the
+                    // font size may have completely changed
+                    if (Math.abs(position.getX()
+                            - lastPosition.getTextPosition().getX()) > (wordSpacing + deltaSpace)
+                                    * 5)
+                    {
+                        maxYForLine = MAX_Y_FOR_LINE_RESET_VALUE;
+                        maxHeightForLine = MAX_HEIGHT_FOR_LINE_RESET_VALUE;
+                        minYTopForLine = MIN_Y_TOP_FOR_LINE_RESET_VALUE;
+                    }
+
                 }
                 if (positionY >= maxYForLine)
                 {

--- a/pdfbox/src/main/java/org/apache/pdfbox/text/PDFTextStripper.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/text/PDFTextStripper.java
@@ -686,17 +686,15 @@ public class PDFTextStripper extends LegacyPDFStreamEngine
                     {
                         line.add(LineItem.getWordSeparator());
                     }
-                    // if there are too many spaces between last character and current, reset the max line height as the
-                    // font size may have completely changed
+                    // if there is at least the equivalent of one space between the last character and the current one,
+                    // reset the max line height as the font size may have completely changed
                     if (Math.abs(position.getX()
-                            - lastPosition.getTextPosition().getX()) > (wordSpacing + deltaSpace)
-                                    * 5)
+                            - lastPosition.getTextPosition().getX()) > (wordSpacing + deltaSpace))
                     {
                         maxYForLine = MAX_Y_FOR_LINE_RESET_VALUE;
                         maxHeightForLine = MAX_HEIGHT_FOR_LINE_RESET_VALUE;
                         minYTopForLine = MIN_Y_TOP_FOR_LINE_RESET_VALUE;
                     }
-
                 }
                 if (positionY >= maxYForLine)
                 {

--- a/pdfbox/src/test/resources/input/PDFBOX-5002.pdf
+++ b/pdfbox/src/test/resources/input/PDFBOX-5002.pdf
@@ -1,0 +1,71 @@
+%PDF-1.4
+%öäüß
+1 0 obj
+<<
+/Type /Catalog
+/Version /1.4
+/Pages 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Kids [3 0 R]
+/Count 1
+>>
+endobj
+3 0 obj
+<<
+/Type /Page
+/MediaBox [0.0 0.0 595.27563 841.8898]
+/Parent 2 0 R
+/Contents 4 0 R
+/Resources 5 0 R
+>>
+endobj
+4 0 obj
+<<
+/Length 148
+/Filter /FlateDecode
+>>
+stream
+xœUÎË‚0…áý<ÅYêFZ"‚[âeoúˆƒ)ÅØzy|‘¤IÍl¿ùg²ƒF®`:Êvü’–OÇ­'…ßø–jC…B•ëUUmËæB#Á2Ä¡ÁY®èF–0=íeSOÏ½´°žE’ðãÀü	xK¸ÅíHõ&¡üÐXË¿C‘ª2¡£Ãð´AîÓ{Vû¨¿R­;Ê
+endstream
+endobj
+5 0 obj
+<<
+/Font 6 0 R
+>>
+endobj
+6 0 obj
+<<
+/F1 7 0 R
+>>
+endobj
+7 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica-Bold
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 8
+0000000000 65535 f
+0000000015 00000 n
+0000000078 00000 n
+0000000135 00000 n
+0000000254 00000 n
+0000000476 00000 n
+0000000509 00000 n
+0000000540 00000 n
+trailer
+<<
+/Root 1 0 R
+/ID [<EDE3E758A49132A45C94EFFE6EAA67F4> <EDE3E758A49132A45C94EFFE6EAA67F4>]
+/Size 8
+>>
+startxref
+642
+%%EOF

--- a/pdfbox/src/test/resources/input/PDFBOX-5002.pdf-sorted.txt
+++ b/pdfbox/src/test/resources/input/PDFBOX-5002.pdf-sorted.txt
@@ -1,0 +1,3 @@
+﻿Title in a big font some text with
+a smaller font
+on multiple lines

--- a/pdfbox/src/test/resources/input/PDFBOX-5002.pdf.txt
+++ b/pdfbox/src/test/resources/input/PDFBOX-5002.pdf.txt
@@ -1,0 +1,3 @@
+﻿Title in a big font some text with
+a smaller font
+on multiple lines

--- a/pdfbox/src/test/resources/input/eu-001.pdf-sorted.txt
+++ b/pdfbox/src/test/resources/input/eu-001.pdf-sorted.txt
@@ -124,10 +124,12 @@ Other organic substances
  to air to water to land 
 kg/year kg/year kg/year 
 Anthracene 50 1 1 
-Benzene 1 000 200 (as 200 (as BTEX) BTEX) 
+Benzene 1 000 200 (as 200 (as 
+BTEX) BTEX) 
 Benzo(g,h,i)perylene - 1 - 
 Di-(2-ethyl hexyl) phthalate (DEHP) 10 1 1 
-Ethyl benzene - 200 (as 200 (as BTEX) BTEX) 
+Ethyl benzene - 200 (as 200 (as 
+BTEX) BTEX) 
 Ethylene oxide 1 000 10 10 
 Fluoranthene - 1 - 
 Naphthalene 100 10 10 
@@ -137,10 +139,12 @@ Octylphenols and octylphenol ethoxylates - 1 -
 Organotin compounds (as total Sn) - 50 50 
 Phenols (as total C) - 20 20 
 Polycyclic Aromatic hydrocarbons (PAHs) 50 5 5 
-Toluene - 200 (as 200 (as BTEX) BTEX) 
+Toluene - 200 (as 200 (as 
+BTEX) BTEX) 
 Total Organic Carbon (TOC) (as total C or 
 COD/3) - 50 000 - 
-Xylenes - 200 (as 200 (as BTEX) BTEX) 
+Xylenes - 200 (as 200 (as 
+BTEX) BTEX) 
  
  
 Inorganic substances 

--- a/pdfbox/src/test/resources/input/eu-001.pdf.txt
+++ b/pdfbox/src/test/resources/input/eu-001.pdf.txt
@@ -148,12 +148,14 @@ kg/year
 to land 
 kg/year 
 Anthracene 50 1 1 
-Benzene 1 000 200 (as BTEX) 
+Benzene 1 000 200 (as 
+BTEX) 
 200 (as 
 BTEX) 
 Benzo(g,h,i)perylene - 1 - 
 Di-(2-ethyl hexyl) phthalate (DEHP) 10 1 1 
-Ethyl benzene - 200 (as BTEX) 
+Ethyl benzene - 200 (as 
+BTEX) 
 200 (as 
 BTEX) 
 Ethylene oxide 1 000 10 10 
@@ -165,12 +167,14 @@ Octylphenols and octylphenol ethoxylates - 1 -
 Organotin compounds (as total Sn) - 50 50 
 Phenols (as total C) - 20 20 
 Polycyclic Aromatic hydrocarbons (PAHs) 50 5 5 
-Toluene - 200 (as BTEX) 
+Toluene - 200 (as 
+BTEX) 
 200 (as 
 BTEX) 
 Total Organic Carbon (TOC) (as total C or 
 COD/3) - 50 000 - 
-Xylenes - 200 (as BTEX) 
+Xylenes - 200 (as 
+BTEX) 
 200 (as 
 BTEX) 
  


### PR DESCRIPTION
The problem lied with the fact that maxHeightForLine is kept, even when the text font changes (which is intentional so as not to trigger a new line when there is sub/superscript). This leads in this case to PDFTextStripper merging two lines that should be separate.
The patch assumes that when the current character is separated from the previous one, the maxHeightForLine has to be reset.
This breaks only one test: eu-001.pdf, and it should as the new code correctly detects two lines where there was only one detected before.

(the patch has been tested with mvn clean test on the 2.0.21 branch with commit bdf2ae77e693cc73d4cdeb9a95c6ac2845d11ead applied, as the current 2.0 branch does not pass tests)

The five-spaces rule is purely arbitrary, but gives good results in my tests. It can be changed but should at least be two I feel.