### PR TITLE
Fix some bad double checked locks

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/color/PDDeviceCMYK.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/color/PDDeviceCMYK.java
@@ -47,7 +47,8 @@ public class PDDeviceCMYK extends PDDeviceColorSpace
     }
 
     private final PDColor initialColor = new PDColor(new float[] { 0, 0, 0, 1 }, this);
-    private volatile ICC_ColorSpace awtColorSpace;
+    private ICC_ColorSpace awtColorSpace;
+    private volatile boolean initDone = false;
     private boolean usePureJavaCMYKConversion = false;
 
     protected PDDeviceCMYK()
@@ -60,14 +61,14 @@ public class PDDeviceCMYK extends PDDeviceColorSpace
     protected void init() throws IOException
     {
         // no need to synchronize this check as it is atomic
-        if (awtColorSpace != null)
+        if (initDone)
         {
             return;
         }
         synchronized (this)
         {
             // we might have been waiting for another thread, so check again
-            if (awtColorSpace != null)
+            if (initDone)
             {
                 return;
             }
@@ -85,6 +86,9 @@ public class PDDeviceCMYK extends PDDeviceColorSpace
             awtColorSpace.toRGB(new float[] { 0, 0, 0, 0 });
             usePureJavaCMYKConversion = System
                     .getProperty("org.apache.pdfbox.rendering.UsePureJavaCMYKConversion") != null;
+
+            // Assignment to volatile must be the LAST statement in this block!
+            initDone = true;
         }
     }
 

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/color/PDDeviceRGB.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/color/PDDeviceRGB.java
@@ -36,7 +36,8 @@ public final class PDDeviceRGB extends PDDeviceColorSpace
     public static final PDDeviceRGB INSTANCE = new PDDeviceRGB();
     
     private final PDColor initialColor = new PDColor(new float[] { 0, 0, 0 }, this);
-    private volatile ColorSpace awtColorSpace;
+    private ColorSpace awtColorSpace;
+    private volatile boolean initDone = false;
 
     private PDDeviceRGB()
     {
@@ -48,7 +49,7 @@ public final class PDDeviceRGB extends PDDeviceColorSpace
     private void init()
     {
         // no need to synchronize this check as it is atomic
-        if (awtColorSpace != null)
+        if (initDone)
         {
             return;
         }
@@ -56,7 +57,7 @@ public final class PDDeviceRGB extends PDDeviceColorSpace
         synchronized (this)
         {
             // we might have been waiting for another thread, so check again
-            if (awtColorSpace != null)
+            if (initDone)
             {
                 return;
             }
@@ -66,6 +67,9 @@ public final class PDDeviceRGB extends PDDeviceColorSpace
             // condition caused by lazy initialization of the color transform, so we perform
             // an initial color conversion while we're still synchronized, see PDFBOX-2184
             awtColorSpace.toRGB(new float[] { 0, 0, 0, 0 });
+
+            // This volatile write must be the LAST statement in the synchronized block!
+            initDone = true;
         }
     }
     


### PR DESCRIPTION
Double checked locking is generally a scary practice, so I explicitly added a new field in these cases. It might also help with some optimizations around actually using the colorSpace object.