### PR TITLE
Unread trailing e when scientific notation was expected

### DIFF
--- a/pdfbox/pom.xml
+++ b/pdfbox/pom.xml
@@ -697,6 +697,19 @@
                             <sha512>5ae7f232c47c13ed31997eb2c368e7deb1013c1321d70bf79369f8d709b33406191d94c21a5d27b4c4bb48241bafd9328a0a6d2d093d4e540d5044e9503bd099</sha512>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>PDFBOX-5025</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>https://issues.apache.org/jira/secure/attachment/13015946/issue3323.pdf</url>
+                            <outputDirectory>${project.build.directory}/pdfs</outputDirectory>
+                            <outputFileName>PDFBOX-5025.pdf</outputFileName>
+                            <sha512>d56d05eea079290133246f10ae327b3d51bd213f9e121717cb70155009608fe3164a174f80f92678e42ac00a9b2041ae7933f4f2c5734c9765cf2b145a28fc64</sha512>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdfparser/BaseParser.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdfparser/BaseParser.java
@@ -953,6 +953,12 @@ public abstract class BaseParser
         {
             seqSource.unread(ic);
         }
+        char lastc = buf.charAt(buf.length() - 1);
+        if (lastc == 'e' || lastc == 'E')
+        {
+            buf.deleteCharAt(buf.length() - 1);
+            seqSource.unread(lastc);
+        }
         return COSNumber.get(buf.toString());
     }
 

--- a/pdfbox/src/test/java/org/apache/pdfbox/pdfparser/TestPDFParser.java
+++ b/pdfbox/src/test/java/org/apache/pdfbox/pdfparser/TestPDFParser.java
@@ -363,6 +363,19 @@ public class TestPDFParser
         doc.close();
     }
 
+    /**
+     * Test that PDFBOX-5025 has 1 page.
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testPDFBox5025() throws IOException
+    {
+        PDDocument doc = PDDocument.load(new File(TARGETPDFDIR, "PDFBOX-5025.pdf"));
+        assertEquals(1, doc.getNumberOfPages());
+        doc.close();
+    }
+
     private void executeParserTest(RandomAccessRead source, MemoryUsageSetting memUsageSetting) throws IOException
     {
         ScratchFile scratchFile = new ScratchFile(memUsageSetting);


### PR DESCRIPTION
Addresses issue https://issues.apache.org/jira/browse/PDFBOX-5025

Unreading the trailing 'e' from the endobject string allows parsing to continue and complete as expected.