### PR TITLE
Rebuild the trailer when missing pages item

### DIFF
--- a/pdfbox/pom.xml
+++ b/pdfbox/pom.xml
@@ -697,6 +697,19 @@
                             <sha512>5ae7f232c47c13ed31997eb2c368e7deb1013c1321d70bf79369f8d709b33406191d94c21a5d27b4c4bb48241bafd9328a0a6d2d093d4e540d5044e9503bd099</sha512>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>PDFBOX-5026</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>https://issues.apache.org/jira/secure/attachment/13015945/issue9418.pdf</url>
+                            <outputDirectory>${project.build.directory}/pdfs</outputDirectory>
+                            <outputFileName>PDFBOX-5026.pdf</outputFileName>
+                            <sha512>1e47caa4246752bc392e596803cb95556bde578b687352a7434d9b77f92892539f810f046e76e4b2300d859ab9a8755a4212378ae099a825367f154919524d7c</sha512>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdfparser/COSParser.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdfparser/COSParser.java
@@ -272,7 +272,7 @@ public class COSParser extends BaseParser
             }
         }
         // check if the trailer contains a Root object
-        if (trailer != null && trailer.getItem(COSName.ROOT) == null)
+        if (trailer != null && !isValidTrailer(trailer))
         {
             rebuildTrailer = isLenient();
         }
@@ -290,6 +290,30 @@ public class COSParser extends BaseParser
             }
         }
         return trailer;
+    }
+
+    /**
+     * Check that the trailer contains a Root object and that the Root
+     * contains a Pages object.
+     *
+     * @param trailer the trailer to validate
+     * @return whether or not the trailer is valid.
+     * @throws IOException if an error occurs
+     */
+    private boolean isValidTrailer(COSDictionary trailer) throws IOException
+    {
+        COSObject root = trailer.getCOSObject(COSName.ROOT);
+        if (root == null)
+        {
+            return false;
+        }
+        COSBase base = parseObjectDynamically(root, false);
+        if (!(base instanceof COSDictionary))
+        {
+            return false;
+        }
+        COSDictionary rootDict = (COSDictionary) base;
+        return rootDict.getDictionaryObject(COSName.PAGES) != null;
     }
 
     /**

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdfparser/COSParser.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdfparser/COSParser.java
@@ -313,7 +313,7 @@ public class COSParser extends BaseParser
             return false;
         }
         COSDictionary rootDict = (COSDictionary) base;
-        return rootDict.getDictionaryObject(COSName.PAGES) != null;
+        return rootDict.getCOSObject(COSName.PAGES) != null;
     }
 
     /**

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdfparser/PDFParser.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdfparser/PDFParser.java
@@ -25,8 +25,6 @@ import org.apache.pdfbox.cos.COSBase;
 import org.apache.pdfbox.cos.COSDictionary;
 import org.apache.pdfbox.cos.COSDocument;
 import org.apache.pdfbox.cos.COSName;
-import org.apache.pdfbox.cos.COSNull;
-import org.apache.pdfbox.cos.COSObject;
 import org.apache.pdfbox.io.IOUtils;
 import org.apache.pdfbox.io.RandomAccessRead;
 import org.apache.pdfbox.io.ScratchFile;
@@ -171,7 +169,6 @@ public class PDFParser extends COSParser
     protected void initialParse() throws IOException
     {
         COSDictionary trailer = retrieveTrailer();
-    
         COSBase base = parseTrailerValuesDynamically(trailer);
         if (!(base instanceof COSDictionary))
         {
@@ -193,12 +190,60 @@ public class PDFParser extends COSParser
         }
         // check pages dictionaries
         checkPages(root);
-        if (!(root.getDictionaryObject(COSName.PAGES) instanceof COSDictionary))
+        boolean foundPages = false;
+        if (root.getDictionaryObject(COSName.PAGES) instanceof COSDictionary)
+        {
+            foundPages = true;
+        }
+        if (!foundPages && isLenient())
+        {
+            root = rebuildTrailerRoot();
+            if (root.getDictionaryObject(COSName.PAGES) instanceof COSDictionary)
+            {
+                foundPages = true;
+            }
+        }
+        if (!foundPages)
         {
             throw new IOException("Page tree root must be a dictionary");
         }
         document.setDecrypted();
         initialParseDone = true;
+    }
+
+    /**
+     * Rebuild the trailer/root dictionary if Pages can't be found.
+     *
+     * @return the rebuild trailer/root dictionary
+     *
+     * @throws IOException if something went wrong
+     */
+    private COSDictionary rebuildTrailerRoot() throws IOException
+    {
+        // Brute force the trailer when pages couldn't be found on the original one
+        COSDictionary trailer = rebuildTrailer();
+        COSBase base = parseTrailerValuesDynamically(trailer);
+        if (!(base instanceof COSDictionary))
+        {
+            throw new IOException("Expected root dictionary, but got this: " + base);
+        }
+        COSDictionary root = (COSDictionary) base;
+        // in some pdfs the type value "Catalog" is missing in the root object
+        if (isLenient() && !root.containsKey(COSName.TYPE))
+        {
+            root.setItem(COSName.TYPE, COSName.CATALOG);
+        }
+        // parse all objects, starting at the root dictionary
+        parseDictObjects(root, (COSName[]) null);
+        // parse all objects of the info dictionary
+        COSBase infoBase = trailer.getDictionaryObject(COSName.INFO);
+        if (infoBase instanceof COSDictionary)
+        {
+            parseDictObjects((COSDictionary) infoBase, (COSName[]) null);
+        }
+        // check pages dictionaries
+        checkPages(root);
+        return root;
     }
 
     /**

--- a/pdfbox/src/test/java/org/apache/pdfbox/pdfparser/TestPDFParser.java
+++ b/pdfbox/src/test/java/org/apache/pdfbox/pdfparser/TestPDFParser.java
@@ -363,6 +363,19 @@ public class TestPDFParser
         doc.close();
     }
 
+    /**
+     * Test that PDFBOX-5026 has pages tree.
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testPDFBox5026() throws IOException
+    {
+        PDDocument doc = PDDocument.load(new File(TARGETPDFDIR, "PDFBOX-5026.pdf"));
+        assertNotNull(doc.getPages());
+        doc.close();
+    }
+
     private void executeParserTest(RandomAccessRead source, MemoryUsageSetting memUsageSetting) throws IOException
     {
         ScratchFile scratchFile = new ScratchFile(memUsageSetting);

--- a/pdfbox/src/test/java/org/apache/pdfbox/pdfparser/TestPDFParser.java
+++ b/pdfbox/src/test/java/org/apache/pdfbox/pdfparser/TestPDFParser.java
@@ -372,7 +372,7 @@ public class TestPDFParser
     public void testPDFBox5026() throws IOException
     {
         PDDocument doc = PDDocument.load(new File(TARGETPDFDIR, "PDFBOX-5026.pdf"));
-        assertNotNull(doc.getPages());
+        assertEquals(1, doc.getNumberOfPages());
         doc.close();
     }
 


### PR DESCRIPTION
Addresses issue https://issues.apache.org/jira/browse/PDFBOX-5026

Rebuilding the trailer when the pages item is missing can allow the building of the PDF when lenient parsing is enabled.