### PR TITLE
PDFBOX-5061 Replace javax.xml.bind by jakarta.xml.bind

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -42,21 +42,6 @@
     <!-- be careful when updating this, because Lucene 8 requires jdk11 -->
   </properties>
 
-  <profiles>
-      <profile>
-          <activation>
-              <jdk>[11,)</jdk>
-          </activation>
-          <dependencies>
-              <dependency>
-                  <groupId>javax.xml.bind</groupId>
-                  <artifactId>jaxb-api</artifactId>
-                  <scope>provided</scope>
-              </dependency>
-          </dependencies>
-      </profile>
-  </profiles>
-
   <dependencies>
     <dependency>
       <groupId>org.bouncycastle</groupId>
@@ -88,7 +73,12 @@
         <groupId>org.apache.lucene</groupId>
         <artifactId>lucene-analyzers-common</artifactId>
         <version>${lucene.version}</version>
-    </dependency>  
+    </dependency>
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>${bind-api.version}</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -50,6 +50,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <bouncycastle.version>1.68</bouncycastle.version>
+        <bind-api.version>3.0.0</bind-api.version>
 
         <!-- This is a default value to avoid problems when running single tests
              see also https://stackoverflow.com/a/28695766/535646 
@@ -163,8 +164,6 @@
             </build>
         </profile>
         <profile>
-            <!-- from jdk11 onwards java.xml.bind is no longer part of the jdk -->
-            <!-- must be set to "test" or "provided" in subprojects --> 
             <id>jdk11</id>
             <activation>
                 <jdk>[11,)</jdk>
@@ -173,15 +172,6 @@
                 <!-- needs to exist even if empty due to problems with jacoco-maven-plugin -->
                 <addmod></addmod>
             </properties>
-            <dependencyManagement>
-                <dependencies>
-                    <dependency>
-                        <groupId>javax.xml.bind</groupId>
-                        <artifactId>jaxb-api</artifactId>
-                        <version>2.3.1</version>
-                    </dependency>
-                </dependencies>
-            </dependencyManagement>
         </profile>
         <profile>
             <id>pedantic</id>

--- a/preflight/pom.xml
+++ b/preflight/pom.xml
@@ -35,21 +35,6 @@
             <skip-bavaria>true</skip-bavaria>
         </properties>
 
-        <profiles>
-            <profile>
-                <activation>
-                    <jdk>[11,)</jdk>
-                </activation>
-                <dependencies>
-                    <dependency>
-                        <groupId>javax.xml.bind</groupId>
-                        <artifactId>jaxb-api</artifactId>
-                        <scope>provided</scope>
-                    </dependency>
-                </dependencies>
-            </profile>
-        </profiles>
-
 	<build>
 		<plugins>
 			<plugin>
@@ -188,6 +173,11 @@
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk15on</artifactId>
 			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>
+			<version>${bind-api.version}</version>
 		</dependency>
                 <dependency>
                     <groupId>org.apache.pdfbox</groupId>

--- a/preflight/src/main/java/org/apache/pdfbox/preflight/PreflightDocument.java
+++ b/preflight/src/main/java/org/apache/pdfbox/preflight/PreflightDocument.java
@@ -132,9 +132,9 @@ public class PreflightDocument extends PDDocument
      */
     public ValidationResult validate() throws ValidationException
     {
-        // force early class loading to check if people forgot to use --add-modules javax.xml.bind
+        // force early class loading to check if people forgot to use --add-modules jakarta.xml.bind
         // on java 9 & 10, or to add jaxb-api on java 11 and later
-        javax.xml.bind.DatatypeConverter.parseInt("0");
+        jakarta.xml.bind.DatatypeConverter.parseInt("0");
         context.setConfig(config);
         Collection<String> processes = config.getProcessNames();
         for (String name : processes)

--- a/xmpbox/pom.xml
+++ b/xmpbox/pom.xml
@@ -31,30 +31,20 @@
 		<relativePath>../parent/pom.xml</relativePath>
 	</parent>
 
-        <profiles>
-            <profile>
-                <activation>
-                    <jdk>[11,)</jdk>
-                </activation>
-                <dependencies>
-                    <dependency>
-                        <groupId>javax.xml.bind</groupId>
-                        <artifactId>jaxb-api</artifactId>
-                        <scope>provided</scope>
-                    </dependency>
-                </dependencies>
-            </profile>
-        </profiles>
-
 	<dependencies>
-	    <dependency>
-	      <groupId>org.junit.jupiter</groupId>
-	      <artifactId>junit-jupiter</artifactId>
-	    </dependency> 
-        <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>commons-logging</groupId>
+			<artifactId>commons-logging</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>
+			<version>${bind-api.version}</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/xmpbox/src/main/java/org/apache/xmpbox/DateConverter.java
+++ b/xmpbox/src/main/java/org/apache/xmpbox/DateConverter.java
@@ -373,7 +373,7 @@ public final class DateConverter
             {
                 toParse = dateString.substring(0, tzIndex) + ":00";
             }
-            Calendar cal = javax.xml.bind.DatatypeConverter.parseDateTime(toParse);
+            Calendar cal = jakarta.xml.bind.DatatypeConverter.parseDateTime(toParse);
 
             TimeZone z = TimeZone.getTimeZone(timeZoneString);
             cal.setTimeZone(z);            
@@ -385,21 +385,21 @@ public final class DateConverter
             int teeIndex = dateString.indexOf('T');
             if (teeIndex == -1)
             {
-                return javax.xml.bind.DatatypeConverter.parseDateTime(dateString);
+                return jakarta.xml.bind.DatatypeConverter.parseDateTime(dateString);
             }
             int plusIndex = dateString.indexOf('+', teeIndex + 1);
             int minusIndex = dateString.indexOf('-', teeIndex + 1);
             if (plusIndex == -1 && minusIndex == -1)
             {
-                return javax.xml.bind.DatatypeConverter.parseDateTime(dateString);
+                return jakarta.xml.bind.DatatypeConverter.parseDateTime(dateString);
             }
             plusIndex = Math.max(plusIndex, minusIndex);
             if (plusIndex - teeIndex == 6)
             {
                 String toParse = dateString.substring(0, plusIndex) + ":00" + dateString.substring(plusIndex);
-                return javax.xml.bind.DatatypeConverter.parseDateTime(toParse);
+                return jakarta.xml.bind.DatatypeConverter.parseDateTime(toParse);
             }
-            return javax.xml.bind.DatatypeConverter.parseDateTime(dateString);
+            return jakarta.xml.bind.DatatypeConverter.parseDateTime(dateString);
         }
     }
 }

--- a/xmpbox/src/test/java/org/apache/xmpbox/DateConverterTest.java
+++ b/xmpbox/src/test/java/org/apache/xmpbox/DateConverterTest.java
@@ -60,41 +60,41 @@ class DateConverterTest
                      DateConverter.toCalendar("2011-11-20T10:09Z"));
         
         // Test some time zone offsets
-        jaxbCal = javax.xml.bind.DatatypeConverter.parseDateTime("2015-02-02T16:37:19.192Z");
+        jaxbCal = jakarta.xml.bind.DatatypeConverter.parseDateTime("2015-02-02T16:37:19.192Z");
         convDate = DateConverter.toCalendar("2015-02-02T16:37:19.192Z");
         assertEquals(dateFormat.format(jaxbCal.getTime()), dateFormat.format(convDate.getTime()));
 
-        jaxbCal = javax.xml.bind.DatatypeConverter.parseDateTime("2015-02-02T16:37:19.192+00:00");
+        jaxbCal = jakarta.xml.bind.DatatypeConverter.parseDateTime("2015-02-02T16:37:19.192+00:00");
         convDate = DateConverter.toCalendar("2015-02-02T16:37:19.192Z");
         assertEquals(dateFormat.format(jaxbCal.getTime()), dateFormat.format(convDate.getTime()));
 
-        jaxbCal = javax.xml.bind.DatatypeConverter.parseDateTime("2015-02-02T16:37:19.192+02:00");
+        jaxbCal = jakarta.xml.bind.DatatypeConverter.parseDateTime("2015-02-02T16:37:19.192+02:00");
         convDate = DateConverter.toCalendar("2015-02-02T16:37:19.192+02:00");
         assertEquals(dateFormat.format(jaxbCal.getTime()), dateFormat.format(convDate.getTime()));
 
-        jaxbCal = javax.xml.bind.DatatypeConverter.parseDateTime("2015-02-02T16:37:19.192Z");
+        jaxbCal = jakarta.xml.bind.DatatypeConverter.parseDateTime("2015-02-02T16:37:19.192Z");
         convDate = DateConverter.toCalendar("2015-02-02T08:37:19.192PST");
         assertEquals(dateFormat.format(jaxbCal.getTime()), dateFormat.format(convDate.getTime()));
 
-        jaxbCal = javax.xml.bind.DatatypeConverter.parseDateTime("2015-02-02T16:37:19.192+01:00");
+        jaxbCal = jakarta.xml.bind.DatatypeConverter.parseDateTime("2015-02-02T16:37:19.192+01:00");
         convDate = DateConverter.toCalendar("2015-02-02T16:37:19.192Europe/Berlin");
         assertEquals(dateFormat.format(jaxbCal.getTime()), dateFormat.format(convDate.getTime()));
 
         // PDFBOX-4902: half-hour TZ
         String time = "2015-02-02T16:37:19.192+05:30";
-        jaxbCal = javax.xml.bind.DatatypeConverter.parseDateTime(time);
+        jaxbCal = jakarta.xml.bind.DatatypeConverter.parseDateTime(time);
         assertEquals(time, DateConverter.toISO8601(jaxbCal, true));
         convDate = DateConverter.toCalendar(time);
         assertEquals(dateFormat.format(jaxbCal.getTime()), dateFormat.format(convDate.getTime()));
 
         time = "2015-02-02T16:37:19.192-05:30";
-        jaxbCal = javax.xml.bind.DatatypeConverter.parseDateTime(time);
+        jaxbCal = jakarta.xml.bind.DatatypeConverter.parseDateTime(time);
         assertEquals(time, DateConverter.toISO8601(jaxbCal, true));
         convDate = DateConverter.toCalendar(time);
         assertEquals(dateFormat.format(jaxbCal.getTime()), dateFormat.format(convDate.getTime()));
 
         time = "2015-02-02T16:37:19.192+10:30";
-        jaxbCal = javax.xml.bind.DatatypeConverter.parseDateTime(time);
+        jaxbCal = jakarta.xml.bind.DatatypeConverter.parseDateTime(time);
         assertEquals(time, DateConverter.toISO8601(jaxbCal, true));
         convDate = DateConverter.toCalendar(time);
         assertEquals(dateFormat.format(jaxbCal.getTime()), dateFormat.format(convDate.getTime()));


### PR DESCRIPTION
This fixes https://issues.apache.org/jira/browse/PDFBOX-5061

Jakarta EE 9 is finally there: https://blogs.eclipse.org/post/mike-milinkovich/jakarta-ee-9-delivers-big-bang. The package name `javax.xml` needed to be replaced by `jakarta.xml`. This PR does it for Apache PDF Box.

I am not sure whether following needs to be added. [My test runs with Java10+](https://github.com/koppor/pdfbox/runs/1619119715?check_suite_focus=true) didn't need it

```xml
            <dependency>
                <groupId>com.sun.xml.bind</groupId>
                <artifactId>jaxb-impl</artifactId>
                <version>3.0.0</version>
                <scope>runtime</scope>
            </dependency>
```