### PR TITLE
Add build using GitHub actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,54 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This file allows PDFBox to be built with GitHub Actions https://github.com/features/actions
+
+name: Build
+on: [workflow_dispatch, push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 8, 9, 10, 11, 12, 13, 14, 15 ]
+        include:
+          - java: 8
+            profile: default
+          - java: 9
+            profile: jdk9
+          - java: 10
+            profile: jdk9
+          - java: 11
+            profile: jdk11
+          - java: 12
+            profile: jdk11
+          - java: 13
+            profile: jdk11
+          - java: 14
+            profile: jdk11
+          - java: 15
+            profile: jdk11
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - run: java -version
+      - name: mvn install
+        run: mvn --batch-mode --update-snapshots -P ${{ matrix.profile }} install


### PR DESCRIPTION
This PR adds a [GitHub workflow](https://github.com/features/actions) to enable checks from all JDKs from version 8 to 15.

The output of GitHub actions is better integrated in GitHub. Furthermore, the errors are highlighted better:

![grafik](https://user-images.githubusercontent.com/1366654/103246045-5c5aa880-4962-11eb-8118-bd09ffa11b8d.png)

