### PR TITLE
Fix the retrieval of number of components for a JPEG image

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/JPEGFactory.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/JPEGFactory.java
@@ -218,12 +218,12 @@ public final class JPEGFactory
         try
         {
             XPath xpath = XPathFactory.newInstance().newXPath();
-            String numScanComponents = xpath.evaluate("markerSequence/sos/@numScanComponents", root);
-            if (numScanComponents.isEmpty())
+            String numFrameComponents = xpath.evaluate("markerSequence/sof/@numFrameComponents", root);
+            if (numFrameComponents.isEmpty())
             {
                 return 0;
             }
-            return Integer.parseInt(numScanComponents);
+            return Integer.parseInt(numFrameComponents);
         }
         catch (NumberFormatException | XPathExpressionException ex)
         {


### PR DESCRIPTION
According to https://docs.oracle.com/javase/8/docs/api/javax/imageio/metadata/doc-files/jpeg_metadata.html the number of image components should be read from the `markerSequence/sof/@numFrameComponents` if you want to retrieve the number of the whole image.

At the moment the number is being read from the first `Start Of Scan marker segment` (sos) xPath encounters which in our case lead to the wrong classification of an image as a Grayscale instead of RGB resulting in a blank image added to the final PDF document.