### PR TITLE
optimize applyMask in PdImageXObject

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/PDImageXObject.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/PDImageXObject.java
@@ -685,7 +685,6 @@ public final class PDImageXObject extends PDXObject implements PDImage
     private static BufferedImage scaleImage(BufferedImage image, int width, int height, int type, boolean interpolate)
     {
         final int imgWidth = image.getWidth(), imgHeight = image.getHeight();
-        System.out.println("scaleImage(" + width + ", " + height + " <- " + imgWidth + ", " + imgHeight + ", " + type + ", " + interpolate);
         // largeScale switch is arbitrarily chosen as to where bicubic becomes very slow
         int computations = type==BufferedImage.TYPE_BYTE_GRAY ? 1 : 3;
         boolean largeScale = ((long)width * height / imgWidth / imgHeight) > 3 * 3 && width * height > 3000 * 3000 * 3 / computations;

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/PDImageXObject.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/PDImageXObject.java
@@ -21,6 +21,7 @@ import java.awt.Paint;
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
 import java.awt.image.BufferedImage;
+import java.awt.image.DataBuffer;
 import java.awt.image.WritableRaster;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
@@ -477,24 +478,24 @@ public final class PDImageXObject extends PDXObject implements PDImage
             }
         }
 
-        // get image as RGB
-        BufferedImage image = SampledImageReader.getRGBImage(this, region, subsampling, getColorKeyMask());
-
+        // get RGB image w/o reference because applyMask might modify it, take long time and a lot of memory. 
+        final BufferedImage image;
+        final PDImageXObject softMask = getSoftMask(), mask = getMask();
         // soft mask (overrides explicit mask)
-        PDImageXObject softMask = getSoftMask();
         if (softMask != null)
         {
-            float[] matte = extractMatte(softMask);
-            image = applyMask(image, softMask.getOpaqueImage(), true, matte);
+            image = applyMask(SampledImageReader.getRGBImage(this, region, subsampling, getColorKeyMask()),
+                softMask.getOpaqueImage(), softMask.getInterpolate(), true, extractMatte(softMask));
+        }
+        // explicit mask - to be applied only if /ImageMask true
+        else if (mask != null && mask.isStencil())
+        {
+            image = applyMask(SampledImageReader.getRGBImage(this, region, subsampling, getColorKeyMask()),
+                mask.getOpaqueImage(), mask.getInterpolate(), false, null);
         }
         else
         {
-            // explicit mask - to be applied only if /ImageMask true
-            PDImageXObject mask = getMask();
-            if (mask != null && mask.isStencil())
-            {
-                image = applyMask(image, mask.getOpaqueImage(), false, null);
-            }
+            image = SampledImageReader.getRGBImage(this, region, subsampling, getColorKeyMask());
         }
 
         if (region == null && subsampling <= cachedImageSubsampling)
@@ -572,9 +573,16 @@ public final class PDImageXObject extends PDXObject implements PDImage
         return SampledImageReader.getRGBImage(this, null);
     }
 
-    // explicit mask: RGB + Binary -> ARGB
-    // soft mask: RGB + Gray -> ARGB
-    private BufferedImage applyMask(BufferedImage image, BufferedImage mask,
+    /**
+     * @param image The image to apply the mask to as alpha channel.
+     * @param mask A mask image in 8 bit Gray. Even for a non soft mask image due to {@link #getOpaqueImage()}
+     *   and {@link SampledImageReader}'s {@code from1Bit()} special handling of DeviceGray.
+     * @param interpolateMask interpolation flag of the mask image.
+     * @param isSoft if a soft mask. If not a soft mask, then alpha needs to be inverted. 
+     * @param matte an optional RGB matte if {@code isSoft==true}.
+     * @return an ARGB image (can be the altered original image)
+     */
+    private BufferedImage applyMask(BufferedImage image, BufferedImage mask, boolean interpolateMask,
                                     boolean isSoft, float[] matte)
     {
         if (mask == null)
@@ -585,81 +593,107 @@ public final class PDImageXObject extends PDXObject implements PDImage
         int width = image.getWidth();
         int height = image.getHeight();
 
-        // scale mask to fit image, or image to fit mask, whichever is larger
+        // scale mask to fit image, or image to fit mask, whichever is larger.
+        // also make sure that image is ARGB as this is what needs to be returned.
         if (mask.getWidth() < width || mask.getHeight() < height)
         {
-            mask = scaleImage(mask, width, height, BufferedImage.TYPE_BYTE_GRAY);
+            mask = scaleImage(mask, width, height, mask.getType(), interpolateMask);
         }
 
         if (mask.getWidth() > width || mask.getHeight() > height)
         {
             width = mask.getWidth();
             height = mask.getHeight();
-            image = scaleImage(image, width, height, BufferedImage.TYPE_INT_ARGB);
+            image = scaleImage(image, width, height, BufferedImage.TYPE_INT_ARGB, getInterpolate());
         }
         else if (image.getType() != BufferedImage.TYPE_INT_ARGB)
         {
-            // always convert to ARGB to allow bulk read / write
-            // PDFBOX-4470 bitonal image has only one element => copy into RGB
-            image = scaleImage(image, width, height, BufferedImage.TYPE_INT_ARGB);
+            image = scaleImage(image, width, height, BufferedImage.TYPE_INT_ARGB, getInterpolate());
         }
 
-        // compose to ARGB
-        BufferedImage masked = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
-        WritableRaster src = image.getRaster();
-        WritableRaster dest = masked.getRaster();
-        WritableRaster alpha = mask.getRaster();
-
-        int[] alphaRow = new int[width];
-        int[] rgbaRow = new int[4 * width];
-        for (int y = 0; y < height; y++)
+        // compose alpha into ARGB image, either:
+        // - very fast by direct bit combination if not a soft mask and a 8 bit alpha source. 
+        // - fast by letting the sample model do a bulk band operation if no matte is set.
+        // - slow and complex by matte calculations on individual pixel components.
+        final WritableRaster raster = image.getRaster(), alpha = mask.getRaster();
+        if ( !isSoft && mask.getType()==BufferedImage.TYPE_BYTE_GRAY
+            && raster.getDataBuffer().getSize() == alpha.getDataBuffer().getSize() )
         {
-            src.getPixels(0, y, width, 1, rgbaRow);
-            alpha.getSamples(0, y, width, 1, 0, alphaRow);
-            for (int x = 0; x < width; x++)
-            {
-                int offset = x * 4;
-                if (isSoft)
-                {
-                    rgbaRow[offset + 3] = alphaRow[x];
-                    if (matte != null && alphaRow[x] != 0)
-                    {
-                        float k = alphaRow[x] / 255f;
-                        rgbaRow[offset + 0] = clampColor(((rgbaRow[offset + 0] / 255f - matte[0]) / k + matte[0]) * 255f);
-                        rgbaRow[offset + 1] = clampColor(((rgbaRow[offset + 1] / 255f - matte[1]) / k + matte[1]) * 255f);
-                        rgbaRow[offset + 2] = clampColor(((rgbaRow[offset + 2] / 255f - matte[2]) / k + matte[2]) * 255f);
-                    }
-                }
-                else
-                {
-                    rgbaRow[offset + 3] = 255 - alphaRow[x];
-                }
+            final DataBuffer dst = raster.getDataBuffer(), src = alpha.getDataBuffer();
+            for ( int i = 0, c = dst.getSize(); c>0; i++, c-- ) {
+                dst.setElem(i, dst.getElem(i) & 0xffffff | ~src.getElem(i) << 24);
             }
-            dest.setPixels(0, y, width, 1, rgbaRow);
         }
-        return masked;
+        else if ( matte==null )
+        {
+            final int[] samples = new int[width];
+            for (int y = 0; y < height; y++)
+            {
+                alpha.getSamples (0, y, width, 1, 0, samples);
+                if ( !isSoft ) for (int x = 0; x < width; x++) samples[x] ^= -1;
+                raster.setSamples(0, y, width, 1, 3, samples);
+            }
+        }
+        else
+        {
+            final int[] alphas = new int[width], pixels = new int[4 * width];
+            // Original code is to clamp component and alpha to [0f, 1f] as matte is, and later expand to [0; 255] again (with rounding).
+            // component = 255f * ((component / 255f - matte) / (alpha / 255f) + matte)
+            //           = (255 * component - 255 * 255f * matte) / alpha + 255f * matte
+            // There is a clearly visible factor 255 for most components in above formula, i.e. max value is 255 * 255: 16 bits + sign.
+            // Let's use faster fixed point integer arithmetics with Q16.15, introducing neglible errors (0.001%).
+            // Note: For "correct" rounding we increase the final matte value (m0h, m1h, m2h) by a half an integer.
+            final int fraction = 15, factor = 255 << fraction;
+            final int m0 = Math.round(factor * matte[0]) * 255, m0h = m0 / 255 + (1 << fraction - 1);
+            final int m1 = Math.round(factor * matte[1]) * 255, m1h = m1 / 255 + (1 << fraction - 1);
+            final int m2 = Math.round(factor * matte[2]) * 255, m2h = m2 / 255 + (1 << fraction - 1);
+            for (int y = 0; y < height; y++)
+            {
+                raster.getPixels(0, y, width, 1, pixels);
+                alpha.getSamples(0, y, width, 1, 0, alphas);
+                for (int x = 0, offset = 0; x < width; )
+                {
+                    int a = alphas[x++];
+                    if (a == 0) {
+                        offset += 3;
+                    } else {
+                        pixels[offset] = clampColor(((pixels[offset++] * factor - m0) / a + m0h) >> fraction);
+                        pixels[offset] = clampColor(((pixels[offset++] * factor - m1) / a + m1h) >> fraction);
+                        pixels[offset] = clampColor(((pixels[offset++] * factor - m2) / a + m2h) >> fraction);
+                    }
+                    pixels[offset++] = a;
+	            }
+	            raster.setPixels(0, y, width, 1, pixels);
+        	}
+        }
+        
+        return image;
     }
 
-    private int clampColor(float color)
+    private static int clampColor(int color)
     {
-        return color < 0 ? 0 : (color > 255 ? 255 : Math.round(color));
+        return color < 0 ? 0 : color > 255 ? 255 : color;
     }
 
     /**
      * High-quality image scaling.
      */
-    private BufferedImage scaleImage(BufferedImage image, int width, int height, int type)
+    private static BufferedImage scaleImage(BufferedImage image, int width, int height, int type, boolean interpolate)
     {
+        final int imgWidth = image.getWidth(), imgHeight = image.getHeight();
         BufferedImage image2 = new BufferedImage(width, height, type);
         Graphics2D g = image2.createGraphics();
-        if (getInterpolate())
+        if (interpolate && (imgWidth!=width || imgHeight!=height))
         {
+            // largeScale switch is arbitrarily chosen as to where bicubic becomes very slow
+            int computations = type==BufferedImage.TYPE_BYTE_GRAY ? 1 : 3;
+            boolean largeScale = ((long)width * height / imgWidth / imgHeight) > 3 * 3 && width * height > 3000 * 3000 * 3 / computations;
             g.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
-                    RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+                largeScale ? RenderingHints.VALUE_INTERPOLATION_BILINEAR : RenderingHints.VALUE_INTERPOLATION_BICUBIC);
             g.setRenderingHint(RenderingHints.KEY_RENDERING,
-                    RenderingHints.VALUE_RENDER_QUALITY);
+                largeScale ? RenderingHints.VALUE_RENDER_SPEED : RenderingHints.VALUE_RENDER_QUALITY);
         }
-        g.drawImage(image, 0, 0, width, height, 0, 0, image.getWidth(), image.getHeight(), null);
+        g.drawImage(image, 0, 0, width, height, 0, 0, imgWidth, imgHeight, null);
         g.dispose();
         return image2;
     }


### PR DESCRIPTION
There was a severe performance issue with really big masks if the image needs to be scaled to it (i.e. 10000*10000 pixels). Scaling bicubic can take 6-10 seconds. This patch tries to switch to bilinear resizing for these cases, although the threshold might have to be fine tuned, still.

There was also a double allocation for the final masked image when we can simply use the image since applyMask() is always fed with a newly created one. Reference hogging and needless allocation have been removed.

Additionally the alpha blending routines were very slow, working on pixels. There is now a staggered approach by:
- direct byte masking which is very fast even for big images (right now does not work with padded buffers),
- exploiting data buffer's sample system to merge the alpha component into the ARGB image, letting the sample model do the bit masking,
- slow pixel expansion to reverse premultiply matte values (but using fixed point integer arithmetics).

Additionally also using the interpolation flag of the mask to decide if the mask should be interpolated.