### PR TITLE
lenient DomXmpParser

### DIFF
--- a/xmpbox/src/main/java/org/apache/xmpbox/xml/DomXmpParser.java
+++ b/xmpbox/src/main/java/org/apache/xmpbox/xml/DomXmpParser.java
@@ -449,11 +449,14 @@ public class DomXmpParser
                     + whatFound
                     + " [prefix=" + prefix + "; name=" + name + "]");
         }
-        if (!bagOrSeq.getLocalName().equals(type.card().name()))
+        String bosname = bagOrSeq.getLocalName();
+        if (!type.card().name().equals(bosname) && (strictParsing || 
+            !(type.card()==Cardinality.Seq && Cardinality.Bag.name().equals(bosname)) &&
+            !(type.card()==Cardinality.Bag && Cardinality.Seq.name().equals(bosname))) )
         {
             // not the good array type
             throw new XmpParsingException(ErrorType.Format, "Invalid array type, expecting " + type.card()
-                    + " and found " + bagOrSeq.getLocalName() + " [prefix="+prefix+"; name="+name+"]");
+                    + " and found " + bosname + " [prefix="+prefix+"; name="+name+"]");
         }
         ArrayProperty array = tm.createArrayProperty(namespace, prefix, name, type.card());
         container.addProperty(array);


### PR DESCRIPTION
The XMP box library is nice, but out in the wild are PDF files that fail parsing. For example dc.create is a Bag instead of a Seq.

Ideally the parser would have a mode where it tries to read as many properties as possible by simply discarding unreadable ones. This is not good if you want to write back a PDF but if you just want to extract Metadata, such a mode would be nice. In this case this invalid dc.creator value would be dropped. This would require doing some more work.

I've seen that there is a non strict parsing mode, which I don't think should be confused with this proposed lenient mode, but as the name suggests it should be less strict. So in this mode Sequences could be read fom Bags and vice versa. I left Alt cardinality as an error because it doesn't really fit in.

Maybe in one of the modes an element that should be an array but isn't could automagically be wrapped into one...

(I also believe that a Bag could always be read from a Sequence...)