### PR TITLE
Lazier clipping

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/state/PDGraphicsState.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/state/PDGraphicsState.java
@@ -632,6 +632,11 @@ public class PDGraphicsState implements Cloneable
         return clippingArea;
     }
 
+    /**
+     * This will get the current clipping path, as one or more individual paths. Do not modify the list or the paths!
+     *
+     * @return The current clipping paths.
+     */
     public List<Path2D.Double> getCurrentClippingPaths()
     {
         return clippingPaths;

--- a/pdfbox/src/main/java/org/apache/pdfbox/rendering/PageDrawer.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/rendering/PageDrawer.java
@@ -140,7 +140,7 @@ public class PageDrawer extends PDFGraphicsStreamEngine
     private GeneralPath linePath = new GeneralPath();
     
     // last clipping path
-    private List<GeneralPath> lastClips;
+    private List<Path2D.Double> lastClips;
 
     // clip when drawPage() is called, can be null, must be intersected when clipping
     private Shape initialClip;
@@ -293,7 +293,7 @@ public class PageDrawer extends PDFGraphicsStreamEngine
         int savedClipWindingRule = clipWindingRule;
         clipWindingRule = -1;
 
-        List<GeneralPath> savedLastClips = lastClips;
+        List<Path2D.Double> savedLastClips = lastClips;
         lastClips = null;
         Shape savedInitialClip = initialClip;
         initialClip = null;
@@ -382,7 +382,7 @@ public class PageDrawer extends PDFGraphicsStreamEngine
      */
     protected final void setClip()
     {
-        List<GeneralPath> clippingPaths = getGraphicsState().getCurrentClippingPaths();
+        List<Path2D.Double> clippingPaths = getGraphicsState().getCurrentClippingPaths();
         if (clippingPaths != lastClips)
         {
             transferClip(getGraphicsState(), graphics);
@@ -1597,7 +1597,7 @@ public class PageDrawer extends PDFGraphicsStreamEngine
                 PDColor backdropColor) throws IOException
         {
             Graphics2D savedGraphics = graphics;
-            List<GeneralPath> savedLastClips = lastClips;
+            List<Path2D.Double> savedLastClips = lastClips;
             Shape savedInitialClip = initialClip;
 
             // get the CTM x Form Matrix transform


### PR DESCRIPTION
Calculating the intersection of two `Area` can take a lot of time. However, depending on the `Graphics2D` that is used for rendering, it may not be necessary to actually perform this operation. 

For instance, when generating an SVG, the individual clipping paths can be serialized individually, and the intersection is then calculated at runtime, when the SVG file is rendered.

The idea of this PR is to replace `PDGraphicsState.clippingPath` with a list of `GeneralPath`s, which is lazily evaluated, truncated & cached when `getCurrentClippingPath()` is called (effectively leaving the current behaviour of PdfBox unchanged, and it should also not have any significant impact on the performance).

Additionally, a new method `protected void transferClip(PDGraphicsState graphicsState, Graphics2D graphics)` is added to `PageDrawer`. By default, this method makes use of `getCurrentClippingPath()` to call `graphics.setClip(...)`, which again is what PdfBox currently does.

However, classes that extend `PageDrawer` can override this method, and directly access the individual clipping paths, without any need to calculate their intersection.

In some cases (shading fills & transparency groups), it is still necessary to calculate the intersection.