### PR TITLE
[bug-fix] Check if `graphics.getClip() != null` before invoking `intersect`

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/rendering/PageDrawer.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/rendering/PageDrawer.java
@@ -820,7 +820,10 @@ public class PageDrawer extends PDFGraphicsStreamEngine
         {
             // apply clip to path to avoid oversized device bounds in shading contexts (PDFBOX-2901)
             Area area = new Area(linePath);
-            area.intersect(new Area(graphics.getClip()));
+            if (graphics.getClip() != null)
+            {
+                area.intersect(new Area(graphics.getClip()));
+            }
             intersectShadingBBox(getGraphicsState().getNonStrokingColor(), area);
             shape = area;
         }


### PR DESCRIPTION
Hey guys!

We got a PDF that manages to trigger the following NPE from `PageDrawer`:

```none
java.lang.NullPointerException: null
	at java.desktop/java.awt.geom.Area.<init>(Area.java:126)
	at org.apache.pdfbox.rendering.PageDrawer.fillPath(PageDrawer.java:900)
	at org.apache.pdfbox.contentstream.operator.graphics.FillNonZeroRule.process(FillNonZeroRule.java:37)
	at org.apache.pdfbox.contentstream.PDFStreamEngine.processOperator(PDFStreamEngine.java:933)
```

The file doesn't even render when loaded on `pdf-debugger`:

<p align="center">
<img src="https://user-images.githubusercontent.com/2560573/139772841-0a196ffc-7998-43de-8ef4-fa867cdeb9e4.png"/>
</p>

Unfortunately, I can’t share the file.

Looking at the documentation for [`Graphics.getClip()`](https://docs.oracle.com/javase/6/docs/api/java/awt/Graphics.html#getClip()), it mentions that the result can be `null`, and if `null` is passed to the `Area` constructor this ends up in a `NullPointerException`. Further studying the `PageDrawer` code, it seems that `graphics.getClip()` shouldn't return `null`, however, the check proposed here seems to do the trick.

#### JIRA ticket

https://issues.apache.org/jira/browse/PDFBOX-5313