### PR TITLE
[feature-request] Additional `showTransparencyGroupOnGraphics()` method

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/rendering/PageDrawer.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/rendering/PageDrawer.java
@@ -1476,6 +1476,12 @@ public class PageDrawer extends PDFGraphicsStreamEngine
     @Override
     public void showTransparencyGroup(PDTransparencyGroup form) throws IOException
     {
+        showTransparencyGroupOnGraphics(form, graphics);
+    }
+
+    protected void showTransparencyGroupOnGraphics(PDTransparencyGroup form, Graphics2D graphics)
+        throws IOException
+    {
         if (isHiddenOCG(form.getOptionalContent()))
         {
             return;


### PR DESCRIPTION
#### Feature Request

Hey team,

In one particular feature of our product, we read PDF files (using PDFBox, of course) and extract graphical elements as individual images for our customers. However, when TGs are decoded, we end up with partial results. For example, given the following [file](https://github.com/apache/pdfbox/files/7457707/testing.pdf): 

<p align="center">
  <img src="https://user-images.githubusercontent.com/2560573/139784518-b3f8965c-79a2-45d6-8200-62fa0e3c4459.png"/>
</p>

Ideally, our flow should extract its graphical content as an individual image:

<p align="center">
  <img src="https://user-images.githubusercontent.com/2560573/139784739-d7562053-0f11-4752-be7f-2ba6659d4816.png"/>
</p>

But after the TGs is decoded, the results we obtain with our current implementation are the following 3 separate images:
<table align="center">
 <tr>
  <td>
    <img src="https://user-images.githubusercontent.com/2560573/139790925-9e69153b-cf63-4b94-82bb-c2406a50c785.png"/>
  </td>
  <td>
    <img width="135px" src="https://user-images.githubusercontent.com/2560573/139790970-79b6cf5d-2939-4861-a47c-e14e3527edb7.png"/>
  </td>
  <td>
    <img width="135px" src="https://user-images.githubusercontent.com/2560573/139791310-ac502454-298e-4cdb-adba-4acdcfd6f7c1.png"/>
  </td>
 </tr>
</table>

We found out that if we manage to pass a particular `Graphics2D` instance to `showTransparencyGroup()` we can redirect the rendering of the TG to a separate image and achieve our feature. This is the purpose of the current PR, we propose a new protected `showTransparencyGroupOnGraphics()` method that extends the current  `showTransparencyGroup()` by taking an additional `Graphics2D` argument.

Keen to hear your thoughts and open to better ideas.

#### JIRA ticket

https://issues.apache.org/jira/browse/PDFBOX-5314