### PR TITLE
Fix Potential Flaky Test in PDFObjectStreamParserTest.java

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdfparser/PDFObjectStreamParser.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdfparser/PDFObjectStreamParser.java
@@ -17,6 +17,7 @@
 package org.apache.pdfbox.pdfparser;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -155,7 +156,7 @@ public class PDFObjectStreamParser extends BaseParser
     private Map<Long, Integer> privateReadObjectNumbers() throws IOException
     {
         // don't initialize map using numberOfObjects as there might by less object numbers than expected
-        Map<Long, Integer> objectNumbers = new HashMap<>();
+        Map<Long, Integer> objectNumbers = new LinkedHashMap<>();
         long firstObjectPosition = source.getPosition() + firstObject - 1;
         for (int i = 0; i < numberOfObjects; i++)
         {


### PR DESCRIPTION
This PR fixes the potential flaky test in `PDFObjectStreamParserTest.java` file.

In the test `testOffsetParsing()`, we convert the keys of `objectNumbers` to the array and assign this array to `numbers`. 


```java
class PDFObjectStreamParserTest
{
    @Test
    void testOffsetParsing() throws IOException
    {
        COSStream stream = new COSStream();
        stream.setItem(COSName.N, COSInteger.TWO);
        stream.setItem(COSName.FIRST, COSInteger.get(8));
        OutputStream outputStream = stream.createOutputStream();
        outputStream.write("1 0 2 5 true false".getBytes());
        outputStream.close();
        PDFObjectStreamParser objectStreamParser = new PDFObjectStreamParser(stream, null);
        Map<Long, Integer> objectNumbers = objectStreamParser.readObjectNumbers();
        assertEquals(2, objectNumbers.size());
        Long[] numbers = objectNumbers.keySet().toArray(new Long[0]); // <<<<<<<<<<<<<<<< LINE: 48
        objectStreamParser = new PDFObjectStreamParser(stream, null);
        assertEquals(COSBoolean.TRUE, objectStreamParser.parseObject(numbers[0]));
        objectStreamParser = new PDFObjectStreamParser(stream, null);
        assertEquals(COSBoolean.FALSE, objectStreamParser.parseObject(numbers[1]));
    }
}
```

However, as the `objectNumbers` is initialized as a HashMap, it is not guaranteed that the order will remain constant over time according to the [Java documentation](https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html). 

> This class makes no guarantees as to the order of the map; in particular, it does not guarantee that the order will remain constant over time.

Such indeterministic characteristic of HashMap will cause this test to fail in some platforms or specific machines that adopt a different iteration order.

To fix it, I looked over our codebase and thought it was doable to initialize our `objectNumbers` as a LinkedHashMap rather than `HashMap`. In this way, the line 48 (variable `numbers`) in `PDFObjectStreamParserTest.java` file will always be deterministic. 

