### PR TITLE
PDFBOX-5363: Don't log warnings if there are not fonts to cache

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/FileSystemFontProvider.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/FileSystemFontProvider.java
@@ -347,11 +347,17 @@ final class FileSystemFontProvider extends FontProvider
             }
             else
             {
-                LOG.warn("Building on-disk font cache, this may take a while");
-                scanFonts(files);
+                if (!files.isEmpty())
+                {
+                    LOG.warn("Building on-disk font cache, this may take a while");
+                    scanFonts(files);
+                }
                 saveDiskCache();
-                LOG.warn("Finished building on-disk font cache, found " +
-                        fontInfoList.size() + " fonts");
+                if (!files.isEmpty())
+                {
+                    LOG.warn("Finished building on-disk font cache, found " +
+                            fontInfoList.size() + " fonts");
+                }
             }
         }
         catch (AccessControlException e)


### PR DESCRIPTION
I kept `saveDiskCache()` out of the `if` block so that the cache file reflects reality (in case it was there already with whichever content).