### PR TITLE
[feature-request] Add a setter for `PageDrawer.graphics`

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/rendering/PageDrawer.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/rendering/PageDrawer.java
@@ -227,6 +227,13 @@ public class PageDrawer extends PDFGraphicsStreamEngine
     }
 
     /**
+     * Sets the underlying Graphics2D.
+     */
+    protected final void setGraphics(Graphics2D graphics) {
+        this.graphics = graphics;
+    }
+
+    /**
      * Returns the current line path. This is reset to empty after each fill/stroke.
      */
     protected final GeneralPath getLinePath()


### PR DESCRIPTION
**Feature request**

Hey folks, the following is to request a small but useful change in `PageDrawer`, consisting of adding a `protected` setter for the the `graphics` member variable.

The idea behind this change is to be able to draw the entire content of a `TransparencyGroup` into a separate image. We already tried using `showTransparencyGroupOnGraphics()` but this doesn't work well for deeply nested and complicated transparency groups.

We set up a proof of concept that sets the parent graphics to the target image through reflection and it worked, but our team would prefer to this through a less hacky way if possible. 

Keen to hear your thoughts and open to better ideas.

**JIRA ticket**

https://issues.apache.org/jira/browse/PDFBOX-5454