### PR TITLE
[PDFBOX-5471] Fall back to an empty `PDRectangle` when Transparency Group `BBox` entry is missing

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/rendering/PageDrawer.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/rendering/PageDrawer.java
@@ -1582,7 +1582,11 @@ public class PageDrawer extends PDFGraphicsStreamEngine
             Matrix transform = Matrix.concatenate(ctm, form.getMatrix());
 
             // transform the bbox
-            GeneralPath transformedBox = form.getBBox().transform(transform);
+            PDRectangle formBbox = form.getBBox();
+            if (formBbox == null) {
+                formBbox = new PDRectangle();
+            }
+            GeneralPath transformedBox = formBbox.transform(transform);
 
             // clip the bbox to prevent giant bboxes from consuming all memory
             Area transformed = new Area(transformedBox);


### PR DESCRIPTION
This PR is a potential fix for https://issues.apache.org/jira/browse/PDFBOX-5471

The change consist of falling back to an empty `PDRectangle` if the Transparency Group `BBox` entry is missing. 

After some testing with some PDF viewer native clients, we couldn't find any visual artifacts or differences.