### PR TITLE
Fix meta markup in HTML generation

### DIFF
--- a/tools/src/main/java/org/apache/pdfbox/tools/PDFText2HTML.java
+++ b/tools/src/main/java/org/apache/pdfbox/tools/PDFText2HTML.java
@@ -64,7 +64,7 @@ public class PDFText2HTML extends PDFTextStripper
                 + "\"http://www.w3.org/TR/html4/loose.dtd\">\n");
         buf.append("<html><head>");
         buf.append("<title>").append(escape(getTitle())).append("</title>\n");
-        buf.append("<meta http-equiv=\"Content-Type\" content=\"text/html; charset=\"UTF-8\">\n");
+        buf.append("<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">\n");
         buf.append("</head>\n");
         buf.append("<body>\n");
         super.writeString(buf.toString());


### PR DESCRIPTION
The current code generates incorrect HTML, a double-quote is never closed in
```
<meta http-equiv="Content-Type" content="text/html; charset="UTF-8">
```
The meta.content attribute does not need internal double-quotes so I removed it.