### PR TITLE
Allow negative struct parent keys in PDFMergerUtility

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/multipdf/PDFMergerUtility.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/multipdf/PDFMergerUtility.java
@@ -795,6 +795,7 @@ public class PDFMergerUtility
                         if (!srcNumberTreeAsMap.isEmpty())
                         {
                             mergeStructTree = true;
+                            destParentTreeNextKey -= Collections.min(srcNumberTreeAsMap.keySet()); // allow for negative struct parent values
                         }
                     }
                 }
@@ -1498,8 +1499,8 @@ public class PDFMergerUtility
         List<PDAnnotation> newannots = new ArrayList<>(annots.size());
         annots.forEach(annot ->
         {
-            int structParent = annot.getStructParent();
-            if (structParent >= 0)
+            int structParent = annot.getCOSObject().getInt(COSName.STRUCT_PARENT, Integer.MIN_VALUE); // allow for negative struct parent values
+            if (structParent > Integer.MIN_VALUE) // allow for negative struct parent values
             {
                 annot.setStructParent(structParent + structParentOffset);
             }


### PR DESCRIPTION
PDFMergerUtility expects structural parent tree keys to be non-negative.
However, negative values don't seem to be forbidden by the specification and are accepted by validators.
This patch adapts the class to handle negative struct parent keys correctly.