### PR TITLE
PDResource font cache improvement

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDResources.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDResources.java
@@ -43,7 +43,7 @@ import org.apache.pdfbox.pdmodel.graphics.PDXObject;
 
 /**
  * A set of resources available at the page/pages/stream level.
- * 
+ *
  * @author Ben Litchfield
  * @author John Hewson
  */
@@ -51,11 +51,10 @@ public final class PDResources implements COSObjectable
 {
     private final COSDictionary resources;
     private final ResourceCache cache;
-    
+
     // PDFBOX-3442 cache fonts that are not indirect objects, as these aren't cached in ResourceCache
     // and this would result in huge memory footprint in text extraction
-    private final Map <COSName,SoftReference<PDFont>> directFontCache = 
-            new HashMap<COSName, SoftReference<PDFont>>();
+    private final Map <COSName,SoftReference<PDFont>> directFontCache;
 
     /**
      * Constructor for embedding.
@@ -64,6 +63,7 @@ public final class PDResources implements COSObjectable
     {
         resources = new COSDictionary();
         cache = null;
+        directFontCache = new HashMap<COSName,SoftReference<PDFont>>();
     }
 
     /**
@@ -79,8 +79,9 @@ public final class PDResources implements COSObjectable
         }
         resources = resourceDictionary;
         cache = null;
+        directFontCache = new HashMap<COSName,SoftReference<PDFont>>();
     }
-    
+
     /**
      * Constructor for reading.
      *
@@ -95,6 +96,24 @@ public final class PDResources implements COSObjectable
         }
         resources = resourceDictionary;
         cache = resourceCache;
+        directFontCache = new HashMap<COSName,SoftReference<PDFont>>();
+    }
+
+    /**
+     * Constructor for reading.
+     *
+     * @param resourceDictionary The cos dictionary for this resource.
+     * @param resourceCache The document's resource cache, may be null.
+     */
+    public PDResources(COSDictionary resourceDictionary, ResourceCache resourceCache,  Map <COSName, SoftReference<PDFont>> directFontCache)
+    {
+        if (resourceDictionary == null)
+        {
+            throw new IllegalArgumentException("resourceDictionary is null");
+        }
+        resources = resourceDictionary;
+        cache = resourceCache;
+        this.directFontCache = directFontCache;
     }
 
     /**
@@ -110,9 +129,9 @@ public final class PDResources implements COSObjectable
      * Returns the font resource with the given name, or null if none exists.
      *
      * @param name Name of the font resource.
-     * 
+     *
      * @return the font resource with the given name.
-     * 
+     *
      * @throws IOException if something went wrong.
      */
     public PDFont getFont(COSName name) throws IOException
@@ -145,7 +164,7 @@ public final class PDResources implements COSObjectable
         {
             font = PDFontFactory.createFont((COSDictionary) base, cache);
         }
-        
+
         if (cache != null && indirect != null)
         {
             cache.put(indirect, font);
@@ -159,7 +178,7 @@ public final class PDResources implements COSObjectable
 
     /**
      * Returns the color space resource with the given name, or null if none exists.
-     * 
+     *
      * @param name Name of the color space resource.
      * @return a new color space.
      * @throws IOException if something went wrong.
@@ -168,7 +187,7 @@ public final class PDResources implements COSObjectable
     {
         return getColorSpace(name, false);
     }
-    
+
     /**
      * Returns the color space resource with the given name, or null if none exists. This method is
      * for PDFBox internal use only, others should use {@link #getColorSpace(COSName)}.
@@ -210,12 +229,12 @@ public final class PDResources implements COSObjectable
         }
         return colorSpace;
     }
-    
+
     /**
      * Returns true if the given color space name exists in these resources.
      *
      * @param name Name of the color space resource.
-     * 
+     *
      * @return true if the color space with the given name exists.
      */
     public boolean hasColorSpace(COSName name)
@@ -227,7 +246,7 @@ public final class PDResources implements COSObjectable
      * Returns the extended graphics state resource with the given name, or null if none exists.
      *
      * @param name Name of the graphics state resource.
-     * 
+     *
      * @return the extended graphics state resource with the given name.
      */
     public PDExtendedGraphicsState getExtGState(COSName name)
@@ -261,9 +280,9 @@ public final class PDResources implements COSObjectable
      * Returns the shading resource with the given name, or null if none exists.
      *
      * @param name Name of the shading resource.
-     * 
+     *
      * @return the shading resource of the given name.
-     * 
+     *
      * @throws IOException if something went wrong.
      */
     public PDShading getShading(COSName name) throws IOException
@@ -285,7 +304,7 @@ public final class PDResources implements COSObjectable
         {
             shading = PDShading.create((COSDictionary) base);
         }
-        
+
         if (cache != null && indirect != null)
         {
             cache.put(indirect, shading);
@@ -295,11 +314,11 @@ public final class PDResources implements COSObjectable
 
     /**
      * Returns the pattern resource with the given name, or null if none exists.
-     * 
+     *
      * @param name Name of the pattern resource.
-     * 
+     *
      * @return the pattern resource of the given name.
-     * 
+     *
      * @throws IOException if something went wrong.
      */
     public PDAbstractPattern getPattern(COSName name) throws IOException
@@ -331,9 +350,9 @@ public final class PDResources implements COSObjectable
 
     /**
      * Returns the property list resource with the given name, or null if none exists.
-     * 
+     *
      * @param name Name of the property list resource.
-     * 
+     *
      * @return the property list resource of the given name.
      */
     public PDPropertyList getProperties(COSName name)
@@ -391,11 +410,11 @@ public final class PDResources implements COSObjectable
 
     /**
      * Returns the XObject resource with the given name, or null if none exists.
-     * 
+     *
      * @param name Name of the XObject resource.
-     * 
+     *
      * @return the XObject resource of the given name.
-     * 
+     *
      * @throws IOException if something went wrong.
      */
     public PDXObject getXObject(COSName name) throws IOException
@@ -480,7 +499,7 @@ public final class PDResources implements COSObjectable
         // not an indirect object. Resource may have been added at runtime.
         return null;
     }
-    
+
     /**
      * Returns the resource with the given name and kind, or null.
      */
@@ -496,7 +515,7 @@ public final class PDResources implements COSObjectable
 
     /**
      * Returns the names of the color space resources, if any.
-     * 
+     *
      * @return the names of all color space resources.
      */
     public Iterable<COSName> getColorSpaceNames()
@@ -506,7 +525,7 @@ public final class PDResources implements COSObjectable
 
     /**
      * Returns the names of the XObject resources, if any.
-     * 
+     *
      * @return the names of all XObject resources.
      */
     public Iterable<COSName> getXObjectNames()
@@ -516,7 +535,7 @@ public final class PDResources implements COSObjectable
 
     /**
      * Returns the names of the font resources, if any.
-     * 
+     *
      * @return the names of all font resources.
      */
     public Iterable<COSName> getFontNames()
@@ -526,7 +545,7 @@ public final class PDResources implements COSObjectable
 
     /**
      * Returns the names of the property list resources, if any.
-     * 
+     *
      * @return the names of all property list resources.
      */
     public Iterable<COSName> getPropertiesNames()
@@ -536,7 +555,7 @@ public final class PDResources implements COSObjectable
 
     /**
      * Returns the names of the shading resources, if any.
-     * 
+     *
      * @return the names of all shading resources.
      */
     public Iterable<COSName> getShadingNames()
@@ -546,7 +565,7 @@ public final class PDResources implements COSObjectable
 
     /**
      * Returns the names of the pattern resources, if any.
-     * 
+     *
      * @return the names of all pattern resources.
      */
     public Iterable<COSName> getPatternNames()
@@ -556,7 +575,7 @@ public final class PDResources implements COSObjectable
 
     /**
      * Returns the names of the extended graphics state resources, if any.
-     * 
+     *
      * @return the names of all extended graphics state resources.
      */
     public Iterable<COSName> getExtGStateNames()
@@ -566,7 +585,7 @@ public final class PDResources implements COSObjectable
 
     /**
      * Returns the resource names of the given kind.
-     * 
+     *
      * @return the names of all resources of the given kind.
      */
     private Iterable<COSName> getNames(COSName kind)
@@ -707,7 +726,7 @@ public final class PDResources implements COSObjectable
             return dict.getKeyForValue(object.getCOSObject());
         }
 
-        // PDFBOX-4509: It could exist as an indirect object, happens when a font is taken from the 
+        // PDFBOX-4509: It could exist as an indirect object, happens when a font is taken from the
         // AcroForm default resources of a loaded PDF.
         if (dict != null && COSName.FONT.equals(kind))
         {
@@ -843,7 +862,7 @@ public final class PDResources implements COSObjectable
 
     /**
      * Returns the resource cache associated with the Resources, or null if there is none.
-     * 
+     *
      * @return the resource cache associated with the resources.
      */
     public ResourceCache getResourceCache()

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDResources.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDResources.java
@@ -104,6 +104,7 @@ public final class PDResources implements COSObjectable
      *
      * @param resourceDictionary The cos dictionary for this resource.
      * @param resourceCache The document's resource cache, may be null.
+     * @param directFontCache The document's direct font cache. Must be mutable
      */
     public PDResources(COSDictionary resourceDictionary, ResourceCache resourceCache,  Map <COSName, SoftReference<PDFont>> directFontCache)
     {


### PR DESCRIPTION
Given:
PDF with AcroForm with N text fields and M fonts loaded.

Problem: 
When PDAcroForm.getDefaultResources() is called, new PDResource with new direct font cache is created. So whenever PDTextField.setValue() is called, PDFontFactory.createFont(), which is expensive operation, is called M + 1 times - M times in AppearanceGeneratorHelper and once when parsing appearance string in PDDefaultAppearanceString. So setting default appearance for N fields would cause fonts to be loaded  N * (M + 1) times.

This PR's intention is to introduce AcroForm-level direct font cache that would be reused in each instance created by PDAcroForm.getDefaultResources()