### PR TITLE
Fix log issues

### DIFF
--- a/fontbox/src/main/java/org/apache/fontbox/ttf/GlyphRenderer.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/GlyphRenderer.java
@@ -151,7 +151,7 @@ class GlyphRenderer
     private void moveTo(GeneralPath path, Point point)
     {
         path.moveTo(point.x, point.y);
-        if (LOG.isDebugEnabled())
+        if (LOG.isTraceEnabled())
         {
             LOG.trace("moveTo: " + String.format(Locale.US, "%d,%d", point.x, point.y));
         }
@@ -160,7 +160,7 @@ class GlyphRenderer
     private void lineTo(GeneralPath path, Point point)
     {
         path.lineTo(point.x, point.y);
-        if (LOG.isDebugEnabled())
+        if (LOG.isTraceEnabled())
         {
             LOG.trace("lineTo: " + String.format(Locale.US, "%d,%d", point.x, point.y));
         }
@@ -169,7 +169,7 @@ class GlyphRenderer
     private void quadTo(GeneralPath path, Point ctrlPoint, Point point)
     {
         path.quadTo(ctrlPoint.x, ctrlPoint.y, point.x, point.y);
-        if (LOG.isDebugEnabled())
+        if (LOG.isTraceEnabled())
         {
             LOG.trace("quadTo: " + String.format(Locale.US, "%d,%d %d,%d", ctrlPoint.x, ctrlPoint.y,
                     point.x, point.y));

--- a/pdfbox/src/test/java/org/apache/pdfbox/text/BidiTest.java
+++ b/pdfbox/src/test/java/org/apache/pdfbox/text/BidiTest.java
@@ -46,7 +46,7 @@ class BidiTest
     /**
      * Logger instance.
      */
-    private static final Log log = LogFactory.getLog(TestTextStripper.class);
+    private static final Log log = LogFactory.getLog(BidiTest.class);
     
     private static final File IN_DIR = new File("src/test/resources/org/apache/pdfbox/text/");
     private static final File outDir = new File("target/test-output");

--- a/preflight/src/test/java/org/apache/pdfbox/preflight/integration/InvalidFileTester.java
+++ b/preflight/src/test/java/org/apache/pdfbox/preflight/integration/InvalidFileTester.java
@@ -39,9 +39,10 @@ import org.apache.pdfbox.preflight.parser.PreflightParser;
 
 public class InvalidFileTester
 {
+    private static final Log LOG = LogFactory.getLog(InvalidFileTester.class);
 
     /**
-     * where result information are pushed
+     * where result information pushed
      */
     protected OutputStream outputResult = null;
 
@@ -49,10 +50,6 @@ public class InvalidFileTester
      * carry the path of the file validated during current test
      */
     protected File path;
-
-    protected static Log staticLogger = LogFactory.getLog("Test");
-
-    protected Log logger = null;
 
     /**
      * Prepare the test for one file
@@ -62,7 +59,6 @@ public class InvalidFileTester
      */
     public InvalidFileTester(String resultKeyFile) throws Exception
     {
-        this.logger = LogFactory.getLog(this.getClass());
         before(resultKeyFile);
     }
 
@@ -70,7 +66,7 @@ public class InvalidFileTester
     {
         if (path == null)
         {
-            logger.warn("This is an empty test");
+            LOG.warn("This is an empty test");
             return;
         }
         ValidationResult result = PreflightParser.validate(path);
@@ -103,7 +99,7 @@ public class InvalidFileTester
         {
             if (expectedError == null)
             {
-                logger.info("File invalid as expected (no expected code) :"
+                LOG.info("File invalid as expected (no expected code) :"
                         + this.path.getAbsolutePath());
             }
             else if (!found)

--- a/preflight/src/test/java/org/apache/pdfbox/preflight/integration/InvalidFileTester.java
+++ b/preflight/src/test/java/org/apache/pdfbox/preflight/integration/InvalidFileTester.java
@@ -42,7 +42,7 @@ public class InvalidFileTester
     private static final Log LOG = LogFactory.getLog(InvalidFileTester.class);
 
     /**
-     * where result information pushed
+     * where result information is pushed
      */
     protected OutputStream outputResult = null;
 


### PR DESCRIPTION
I fixed some smaller problems with logging in trunk:
- GlyphRenderer conditions and logging calls did not match leading to unnecessary string formatting when log level is debug
- BidiTest logger was initialized with the wrong class
- InvalidFileTest used a non-static, non-final logger without reason