### PR TITLE
small code cleanups

### DIFF
--- a/debugger/src/main/java/org/apache/pdfbox/debugger/ui/OSXAdapter.java
+++ b/debugger/src/main/java/org/apache/pdfbox/debugger/ui/OSXAdapter.java
@@ -165,7 +165,7 @@ public class OSXAdapter implements InvocationHandler
         // com.apple.eawt.Application reflectively
         try {
             Method enableAboutMethod = macOSXApplication.getClass().getDeclaredMethod("setEnabledAboutMenu", boolean.class);
-            enableAboutMethod.invoke(macOSXApplication, Boolean.valueOf(enableAboutMenu));
+            enableAboutMethod.invoke(macOSXApplication, enableAboutMenu);
         } catch (Exception ex) {
             System.err.println("OSXAdapter could not access the About Menu");
             throw new RuntimeException(ex);
@@ -296,7 +296,7 @@ public class OSXAdapter implements InvocationHandler
         if (result == null) {
             return true;
         }
-        return Boolean.valueOf(result.toString());
+        return Boolean.parseBoolean(result.toString());
     }
 
     // InvocationHandler implementation
@@ -323,7 +323,7 @@ public class OSXAdapter implements InvocationHandler
             try {
                 Method setHandledMethod = event.getClass().getDeclaredMethod("setHandled", boolean.class);
                 // If the target method returns a boolean, use that as a hint
-                setHandledMethod.invoke(event, Boolean.valueOf(handled));
+                setHandledMethod.invoke(event, handled);
             } catch (Exception ex) {
                 System.err.println("OSXAdapter was unable to handle an ApplicationEvent: " + event);
                 throw new RuntimeException(ex);

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDDocument.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDDocument.java
@@ -441,8 +441,8 @@ public class PDDocument implements Closeable
         if (!(checkFields &&
               annotations instanceof COSArrayList &&
               acroFormFields instanceof COSArrayList &&
-              ((COSArrayList) annotations).toList().
-                      equals(((COSArrayList) acroFormFields).toList())))
+              ((COSArrayList<?>) annotations).toList().
+                      equals(((COSArrayList<?>) acroFormFields).toList())))
         {
             // use check to prevent the annotation widget from appearing twice
             if (checkSignatureAnnotation(annotations, firstWidget))

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/form/PDFieldTree.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/form/PDFieldTree.java
@@ -71,7 +71,7 @@ public class PDFieldTree implements Iterable<PDField>
         // PDFBOX-5044: to prevent recursion
         // must be COSDictionary and not PDField, because PDField is newly created each time
         private final Set<COSDictionary> set =
-                Collections.newSetFromMap(new IdentityHashMap<COSDictionary, Boolean>());
+                Collections.newSetFromMap(new IdentityHashMap<>());
 
         private FieldIterator(PDAcroForm form)
         {

--- a/pdfbox/src/test/java/org/apache/pdfbox/cos/TestCOSString.java
+++ b/pdfbox/src/test/java/org/apache/pdfbox/cos/TestCOSString.java
@@ -237,7 +237,7 @@ class TestCOSString extends TestCOSBase
         
         out.reset();
         COSWriter.writeString(string8Bit, out);
-        StringBuffer hex = new StringBuffer();
+        StringBuilder hex = new StringBuilder();
         for(char c : text8Bit.toCharArray())
         {
            hex.append( Integer.toHexString(c).toUpperCase() );
@@ -246,7 +246,7 @@ class TestCOSString extends TestCOSBase
         
         out.reset();
         COSWriter.writeString(stringHighBits, out);
-        hex = new StringBuffer();
+        hex = new StringBuilder();
         hex.append("FEFF"); // Byte Order Mark
         for(char c : textHighBits.toCharArray())
         {

--- a/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/font/TestToUnicodeWriter.java
+++ b/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/font/TestToUnicodeWriter.java
@@ -114,10 +114,10 @@ class TestToUnicodeWriter
     @Test
     void testAllowCIDToUnicodeRange()
     {
-        Map.Entry<Integer, String> six = new AbstractMap.SimpleEntry<Integer, String>(0x03FF, "6");
-        Map.Entry<Integer, String> seven = new AbstractMap.SimpleEntry<Integer, String>(0x0400,
+        Map.Entry<Integer, String> six = new AbstractMap.SimpleEntry<>(0x03FF, "6");
+        Map.Entry<Integer, String> seven = new AbstractMap.SimpleEntry<>(0x0400,
                 "7");
-        Map.Entry<Integer, String> eight = new AbstractMap.SimpleEntry<Integer, String>(0x0401,
+        Map.Entry<Integer, String> eight = new AbstractMap.SimpleEntry<>(0x0401,
                 "8");
 
         assertFalse(ToUnicodeWriter.allowCIDToUnicodeRange(null, seven));

--- a/tools/src/main/java/org/apache/pdfbox/tools/PDFToImage.java
+++ b/tools/src/main/java/org/apache/pdfbox/tools/PDFToImage.java
@@ -113,7 +113,7 @@ public final class PDFToImage implements Callable<Integer>
             outputPrefix = FilenameUtils.removeExtension(infile.getAbsolutePath());
         }
 
-        if (getImageFormats().indexOf(imageFormat) == -1)
+        if (!getImageFormats().contains(imageFormat))
         {
             SYSERR.println( "Error: Invalid image format " + imageFormat + " - supported are: " + getImageFormats());
             return 2;

--- a/xmpbox/src/main/java/org/apache/xmpbox/type/RealType.java
+++ b/xmpbox/src/main/java/org/apache/xmpbox/type/RealType.java
@@ -81,7 +81,7 @@ public class RealType extends AbstractSimpleProperty
         else if (value instanceof String)
         {
             // NumberFormatException is thrown (sub of InvalidArgumentException)
-            realValue = Float.valueOf((String) value);
+            realValue = Float.parseFloat((String) value);
         }
         else
         {

--- a/xmpbox/src/test/java/org/apache/xmpbox/schema/XMPSchemaTest.java
+++ b/xmpbox/src/test/java/org/apache/xmpbox/schema/XMPSchemaTest.java
@@ -209,7 +209,7 @@ class XMPSchemaTest
         schem.addUnqualifiedSequenceValue(seqprop, seqPropVal);
         schem.addSequenceDateValueAsSimple(seqdate, dateVal);
 
-        assertEquals(Boolean.valueOf(boolVal), schem.getBooleanProperty(prefSchem + bool).getValue());
+        assertEquals(boolVal, schem.getBooleanProperty(prefSchem + bool).getValue());
         assertEquals(dateVal, schem.getDateProperty(prefSchem + date).getValue());
         assertEquals("" + i, schem.getIntegerProperty(prefSchem + integ).getStringValue());
         assertEquals(langVal, schem.getUnqualifiedLanguagePropertyValue(langprop, lang));
@@ -218,7 +218,7 @@ class XMPSchemaTest
         assertTrue(schem.getUnqualifiedSequenceDateValueList(seqdate).contains(dateVal));
         assertTrue(schem.getUnqualifiedLanguagePropertyLanguagesValue(langprop).contains(lang));
 
-        assertEquals(boolVal, schem.getBooleanPropertyValueAsSimple(bool).booleanValue());
+        assertEquals(boolVal, schem.getBooleanPropertyValueAsSimple(bool));
         assertEquals(dateVal, schem.getDatePropertyValueAsSimple(date));
         assertEquals(i, schem.getIntegerPropertyValueAsSimple(integ));
         assertEquals(langVal, schem.getUnqualifiedLanguagePropertyValue(langprop, lang));


### PR DESCRIPTION
- in some places, unnecessary explicit boxing/unboxing was done
- I replaced some XXX.valueOf(String) calls with the corresponding XXX.parseXXX(String) calls. XXX.valueOf() always returns a boxed value, but when that is assigned to a primitive, the boxing/unboxing is needless.
- added generics information or the diamond operator ('<>') so that IDEs keep silent about using raw types
- replaced explicit generic parameters with diamond operator where applicable
- changed String.indexOf(...)==0 with String.contains(...) in one place