### PR TITLE
fix unnecessary boxing/unboxing

### DIFF
--- a/debugger/src/main/java/org/apache/pdfbox/debugger/ui/OSXAdapter.java
+++ b/debugger/src/main/java/org/apache/pdfbox/debugger/ui/OSXAdapter.java
@@ -165,7 +165,7 @@ public class OSXAdapter implements InvocationHandler
         // com.apple.eawt.Application reflectively
         try {
             Method enableAboutMethod = macOSXApplication.getClass().getDeclaredMethod("setEnabledAboutMenu", boolean.class);
-            enableAboutMethod.invoke(macOSXApplication, Boolean.valueOf(enableAboutMenu));
+            enableAboutMethod.invoke(macOSXApplication, enableAboutMenu);
         } catch (Exception ex) {
             System.err.println("OSXAdapter could not access the About Menu");
             throw new RuntimeException(ex);
@@ -296,7 +296,7 @@ public class OSXAdapter implements InvocationHandler
         if (result == null) {
             return true;
         }
-        return Boolean.valueOf(result.toString());
+        return Boolean.parseBoolean(result.toString());
     }
 
     // InvocationHandler implementation
@@ -323,7 +323,7 @@ public class OSXAdapter implements InvocationHandler
             try {
                 Method setHandledMethod = event.getClass().getDeclaredMethod("setHandled", boolean.class);
                 // If the target method returns a boolean, use that as a hint
-                setHandledMethod.invoke(event, Boolean.valueOf(handled));
+                setHandledMethod.invoke(event, handled);
             } catch (Exception ex) {
                 System.err.println("OSXAdapter was unable to handle an ApplicationEvent: " + event);
                 throw new RuntimeException(ex);

--- a/xmpbox/src/main/java/org/apache/xmpbox/type/RealType.java
+++ b/xmpbox/src/main/java/org/apache/xmpbox/type/RealType.java
@@ -81,7 +81,7 @@ public class RealType extends AbstractSimpleProperty
         else if (value instanceof String)
         {
             // NumberFormatException is thrown (sub of InvalidArgumentException)
-            realValue = Float.valueOf((String) value);
+            realValue = Float.parseFloat((String) value);
         }
         else
         {

--- a/xmpbox/src/test/java/org/apache/xmpbox/schema/XMPSchemaTest.java
+++ b/xmpbox/src/test/java/org/apache/xmpbox/schema/XMPSchemaTest.java
@@ -209,7 +209,7 @@ class XMPSchemaTest
         schem.addUnqualifiedSequenceValue(seqprop, seqPropVal);
         schem.addSequenceDateValueAsSimple(seqdate, dateVal);
 
-        assertEquals(Boolean.valueOf(boolVal), schem.getBooleanProperty(prefSchem + bool).getValue());
+        assertEquals(boolVal, schem.getBooleanProperty(prefSchem + bool).getValue());
         assertEquals(dateVal, schem.getDateProperty(prefSchem + date).getValue());
         assertEquals("" + i, schem.getIntegerProperty(prefSchem + integ).getStringValue());
         assertEquals(langVal, schem.getUnqualifiedLanguagePropertyValue(langprop, lang));
@@ -218,7 +218,7 @@ class XMPSchemaTest
         assertTrue(schem.getUnqualifiedSequenceDateValueList(seqdate).contains(dateVal));
         assertTrue(schem.getUnqualifiedLanguagePropertyLanguagesValue(langprop).contains(lang));
 
-        assertEquals(boolVal, schem.getBooleanPropertyValueAsSimple(bool).booleanValue());
+        assertEquals(boolVal, schem.getBooleanPropertyValueAsSimple(bool));
         assertEquals(dateVal, schem.getDatePropertyValueAsSimple(date));
         assertEquals(i, schem.getIntegerPropertyValueAsSimple(integ));
         assertEquals(langVal, schem.getUnqualifiedLanguagePropertyValue(langprop, lang));


### PR DESCRIPTION
Most of the changes make the code just more readable and the compiler does auto(un)boxing where necessary.

Replacing `Boolean.valueOf()` and `Float.valueOf()` on the other hand completely avoids a boxing/unboxing cycle because in both cases the result is stored in a primitive.