### PR TITLE
pdfbox cli : fix support import:xfdf

### DIFF
--- a/tools/src/main/java/org/apache/pdfbox/tools/ImportXFDF.java
+++ b/tools/src/main/java/org/apache/pdfbox/tools/ImportXFDF.java
@@ -22,6 +22,7 @@ import org.apache.pdfbox.pdmodel.PDDocumentCatalog;
 import org.apache.pdfbox.pdmodel.fdf.FDFDocument;
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
 
+
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -29,6 +30,7 @@ import picocli.CommandLine.Option;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.concurrent.Callable;
 
 
 /**
@@ -38,7 +40,7 @@ import java.io.PrintStream;
  * @author Ben Litchfield
  */
 @Command(name = "importxfdf", header = "Imports AcroForm form data from XFDF", versionProvider = Version.class, mixinStandardHelpOptions = true)
-public class ImportXFDF
+public class ImportXFDF implements Callable<Integer>
 {
     // Expected for CLI app to write to System.out/System.err
     @SuppressWarnings("squid:S106")


### PR DESCRIPTION
This will fix this error when using **pdfbox cli** with action **import:xfdf** :

```
picocli.CommandLine$ExecutionException: Parsed command (org.apache.pdfbox.tools.ImportXFDF@78dd667e) is not a Method, Runnable or Callable
	at picocli.CommandLine.executeUserObject(CommandLine.java:1993)
	at picocli.CommandLine.access$1300(CommandLine.java:145)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2358)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2352)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2314)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2179)
	at picocli.CommandLine$RunLast.execute(CommandLine.java:2316)
	at picocli.CommandLine.execute(CommandLine.java:2078)
	at org.apache.pdfbox.tools.PDFBox.main(PDFBox.java:76)
```
