### PR TITLE
Avoid division by 0 in shading function interpolation

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/common/function/PDFunction.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/common/function/PDFunction.java
@@ -348,6 +348,9 @@ public abstract class PDFunction implements COSObjectable
      */
     protected float interpolate(float x, float xRangeMin, float xRangeMax, float yRangeMin, float yRangeMax) 
     {
+        if (xRangeMax == xRangeMin) {
+            return yRangeMin;
+        }
         return yRangeMin + ((x - xRangeMin) * (yRangeMax - yRangeMin)/(xRangeMax - xRangeMin));
     }
 


### PR DESCRIPTION
I am seeing a case of division by `0f` (producing a NaN) when trying to evaluate a gradient with a specific type 3 color function.

The gradient renders correctly with PDFbox, because the error affects only one point of the gradient (at `x = 1`). But when I call `shading.eval(new float[] {1.0})` I get the wrong color (black) instead of a shade of blue. I did a small investigation and found this:

I believe pdfbox isn't complying with the following sentence in the spec for functionType 3 (see section 3.9 - page 175 of the PDF reference version 1.7). Please see the reference for context, as this sentence alone is rather cryptic
> If the last bound, Bounds<sub>k−2</sub>, is equal to Domain<sub>1</sub>, then x′ is defined to
be Encode<sub>2i</sub>. 


Here is a simple PDF that reproduces the error: [gradient-bug.pdf](https://github.com/apache/pdfbox/files/11350511/gradient-bug.pdf)
In that example, the type3 color function has 3 sub functions and the following parameters:
Bounds = [0.00188385, 1]
Domain = [0, 1]
Encode = [0, 1, 0, 1, 0, 1]

When trying to evaluate the `interpolate` function at `x = 1.0` with the following parameters, we get a NaN
![Screenshot 2023-04-28 at 2 32 32 pm](https://user-images.githubusercontent.com/25138293/235056669-ef1c4628-9f90-4ba8-9db6-10a1b6916771.png)
![Screenshot 2023-04-28 at 2 33 08 pm](https://user-images.githubusercontent.com/25138293/235056870-6e1cf826-68ea-456a-8a88-6101b7506260.png)

Let me know if I can help further