### PR TITLE
PDFBOX-5687 - PDFBox 3.0 OSGi bundle requires sun.java2d.cmm.kcms package

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -383,6 +383,11 @@
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
                     <version>5.1.9</version>
+                    <configuration>
+                        <instructions>
+                            <_noclassforname>true</_noclassforname>
+                        </instructions>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Disable generating Import-Package statements for "Class.forName" calls completely.