### PR TITLE
extract class refactoring.

### DIFF
--- a/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/CreatePatternsPDF.java
+++ b/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/CreatePatternsPDF.java
@@ -36,95 +36,100 @@ import org.apache.pdfbox.pdmodel.graphics.pattern.PDTilingPattern;
  *
  * @author Tilman Hausherr
  */
-public final class CreatePatternsPDF
-{
-    private CreatePatternsPDF()
-    {
-    }
+public final class CreatePatternsPDF {
 
-    public static void main(String[] args) throws IOException
-    {
-        try (PDDocument doc = new PDDocument())
-        {
+    public static void main(String[] args) throws IOException {
+        try (PDDocument doc = new PDDocument()) {
             PDPage page = new PDPage();
             doc.addPage(page);
             page.setResources(new PDResources());
-            
-            // Colored pattern, i.e. the pattern content stream will set its own color(s)
-            try (PDPageContentStream pcs = new PDPageContentStream(doc, page))
-            {
-                // Colored pattern, i.e. the pattern content stream will set its own color(s)
-                PDColorSpace patternCS1 = new PDPattern(null, PDDeviceRGB.INSTANCE);
-                
-                // Table 75 spec
-                PDTilingPattern tilingPattern1 = new PDTilingPattern();
-                tilingPattern1.setBBox(new PDRectangle(0, 0, 10, 10));
-                tilingPattern1.setPaintType(PDTilingPattern.PAINT_COLORED);
-                tilingPattern1.setTilingType(PDTilingPattern.TILING_CONSTANT_SPACING);
-                tilingPattern1.setXStep(10);
-                tilingPattern1.setYStep(10);
-                
-                COSName patternName1 = page.getResources().add(tilingPattern1);
-                try (PDPatternContentStream cs1 = new PDPatternContentStream(tilingPattern1))
-                {
-                    // Set color, draw diagonal line + 2 more diagonals so that corners look good
-                    cs1.setStrokingColor(Color.red);
-                    cs1.moveTo(0, 0);
-                    cs1.lineTo(10, 10);
-                    cs1.moveTo(-1, 9);
-                    cs1.lineTo(1, 11);
-                    cs1.moveTo(9, -1);
-                    cs1.lineTo(11, 1);
-                    cs1.stroke();
-                }
-                
-                PDColor patternColor1 = new PDColor(patternName1, patternCS1);
-                
-                pcs.addRect(50, 500, 200, 200);
-                pcs.setNonStrokingColor(patternColor1);
-                pcs.fill();
-                
-                // Uncolored pattern - the color is passed later
-                PDTilingPattern tilingPattern2 = new PDTilingPattern();
-                tilingPattern2.setBBox(new PDRectangle(0, 0, 10, 10));
-                tilingPattern2.setPaintType(PDTilingPattern.PAINT_UNCOLORED);
-                tilingPattern2.setTilingType(PDTilingPattern.TILING_NO_DISTORTION);
-                tilingPattern2.setXStep(10);
-                tilingPattern2.setYStep(10);
-                
-                COSName patternName2 = page.getResources().add(tilingPattern2);
-                try (PDPatternContentStream cs2 = new PDPatternContentStream(tilingPattern2))
-                {
-                    // draw a cross
-                    cs2.moveTo(0, 5);
-                    cs2.lineTo(10, 5);
-                    cs2.moveTo(5, 0);
-                    cs2.lineTo(5, 10);
-                    cs2.stroke();
-                }
 
-                // Uncolored pattern colorspace needs to know the colorspace
-                // for the color values that will be passed when painting the fill
-                PDColorSpace patternCS2 = new PDPattern(null, PDDeviceRGB.INSTANCE);
-                PDColor patternColor2green = new PDColor(
-                        new float[]{0,1,0},
-                        patternName2,
-                        patternCS2);
-                
-                pcs.addRect(300, 500, 100, 100);
-                pcs.setNonStrokingColor(patternColor2green);
-                pcs.fill();
-                
-                // same pattern again but with different color + different pattern start position
-                PDColor patternColor2blue = new PDColor(
-                        new float[]{0,0,1},
-                        patternName2,
-                        patternCS2);
-                pcs.addRect(455, 505, 100, 100);
-                pcs.setNonStrokingColor(patternColor2blue);
-                pcs.fill();
+            PatternDrawer drawer = new PatternDrawer(doc, page);
+
+            // Colored pattern, i.e. the pattern content stream will set its own color(s)
+
+            // Table 75 spec
+            PDTilingPattern coloredTilingPattern = drawer.createTilingPattern(
+                    new PDRectangle(0, 0, 10, 10),
+                    PDTilingPattern.PAINT_COLORED,
+                    PDTilingPattern.TILING_CONSTANT_SPACING,
+                    10,
+                    10);
+            COSName coloredTilingPatternName = page.getResources().add(coloredTilingPattern);
+            try (PDPatternContentStream cs = new PDPatternContentStream(coloredTilingPattern))
+            {
+                // Set color, draw diagonal line + 2 more diagonals so that corners look good
+                cs.setStrokingColor(Color.red);
+                cs.moveTo(0, 0);
+                cs.lineTo(10, 10);
+                cs.moveTo(-1, 9);
+                cs.lineTo(1, 11);
+                cs.moveTo(9, -1);
+                cs.lineTo(11, 1);
+                cs.stroke();
             }
+            PDColorSpace coloredPatternCS = new PDPattern(null, PDDeviceRGB.INSTANCE);
+            PDColor patternColor = new PDColor(coloredTilingPatternName, coloredPatternCS);
+            drawer.drawPattern(50, 500, 200, 200, patternColor);
+
+            // Uncolored pattern - the color is passed later
+
+            PDTilingPattern uncoloredTilingPattern = drawer.createTilingPattern(
+                    new PDRectangle(0, 0, 10, 10),
+                    PDTilingPattern.PAINT_UNCOLORED,
+                    PDTilingPattern.TILING_NO_DISTORTION,
+                    10,
+                    10);
+            COSName uncoloredTilingPatternName = page.getResources().add(uncoloredTilingPattern);
+            try (PDPatternContentStream cs = new PDPatternContentStream(uncoloredTilingPattern))
+            {
+                // draw a cross
+                cs.moveTo(0, 5);
+                cs.lineTo(10, 5);
+                cs.moveTo(5, 0);
+                cs.lineTo(5, 10);
+                cs.stroke();
+            }
+
+            // Uncolored pattern colorspace needs to know the colorspace
+            // for the color values that will be passed when painting the fill
+            PDColorSpace uncoloredPatternCS = new PDPattern(null, PDDeviceRGB.INSTANCE);
+            PDColor patternColor2green = new PDColor(new float[]{0, 1, 0}, uncoloredTilingPatternName, uncoloredPatternCS);
+            drawer.drawPattern(300, 500, 100, 100, patternColor2green);
+
+            // same pattern again but with different color + different pattern start position
+            PDColor patternColor2blue = new PDColor(new float[]{0, 0, 1}, uncoloredTilingPatternName, uncoloredPatternCS);
+            drawer.drawPattern(455, 505, 100, 100, patternColor2blue);
+
             doc.save("patterns.pdf");
         }
+    }
+}
+
+final class PatternDrawer{
+    private final PDDocument document;
+    private final PDPage page;
+
+    public PatternDrawer(PDDocument document, PDPage page) {
+        this.document = document;
+        this.page = page;
+    }
+
+    public void drawPattern(float x, float y, float width, float height, PDColor patternColor) throws IOException {
+        try (PDPageContentStream pcs = new PDPageContentStream(document, page)) {
+            pcs.addRect(x, y, width, height);
+            pcs.setNonStrokingColor(patternColor);
+            pcs.fill();
+        }
+    }
+
+    public PDTilingPattern createTilingPattern(PDRectangle pdRectangle, int paintType, int tilingType, float xStep, float yStep){
+        PDTilingPattern tilingPattern = new PDTilingPattern();
+        tilingPattern.setBBox(pdRectangle);
+        tilingPattern.setPaintType(paintType);
+        tilingPattern.setTilingType(tilingType);
+        tilingPattern.setXStep(xStep);
+        tilingPattern.setYStep(yStep);
+        return tilingPattern;
     }
 }


### PR DESCRIPTION
### Extract Class Refactoring

**Location of the class:** org.apache.pdfbox.examples.pdmodel.CreatePatternsPDF

**Reason:** Imperative Abstraction - The tool detected the smell in this class because it looks like that an operation is turned into a class. This class contains only the following public method: main

**Logic of the refactoring:** New class (PatternDrawer) is created to refactor the code and refactored code separates the responsibilities of two classes (CreatePatternsPDF and PatternDrawer).