### PR TITLE
push down method refactoring.

### DIFF
--- a/fontbox/src/main/java/org/apache/fontbox/ttf/OTFParser.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/OTFParser.java
@@ -62,7 +62,6 @@ public final class OTFParser extends TTFParser
         return new OpenTypeFont(raf);
     }
 
-    @Override
     protected TTFTable readTable(String tag)
     {
         // todo: this is a stub, a full implementation is needed
@@ -77,7 +76,7 @@ public final class OTFParser extends TTFParser
             case CFFTable.TAG:
                 return new CFFTable();
             default:
-                return super.readTable(tag);
+                return new TTFTable();
         }
     }
 

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/TTFParser.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/TTFParser.java
@@ -289,7 +289,7 @@ public class TTFParser
                 table = new GlyphSubstitutionTable();
                 break;
             default:
-                table = readTable(tag);
+                table = new TTFTable();
                 break;
         }
         table.setTag(tag);
@@ -304,11 +304,5 @@ public class TTFParser
         }
 
         return table;
-    }
-
-    protected TTFTable readTable(String tag)
-    {
-        // unknown table type but read it anyway.
-        return new TTFTable();
     }
 }


### PR DESCRIPTION
### Push Down Method Refactoring

**Reason:** Rebellious Hierarchy - Method of subclass reject the methods provided by its supertypes because supertype's method only returns the empty object. The method that reject the suptertype's method is: readTable
**Logic of the Refactoring:** Removed the method from the super-type.