### PR TITLE
Guard PDRange constructors against invalid ranges

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/common/PDRange.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/common/PDRange.java
@@ -16,6 +16,7 @@
  */
 package org.apache.pdfbox.pdmodel.common;
 
+import java.util.Objects;
 import org.apache.pdfbox.cos.COSArray;
 import org.apache.pdfbox.cos.COSBase;
 import org.apache.pdfbox.cos.COSFloat;
@@ -46,10 +47,18 @@ public class PDRange implements COSObjectable
      * Constructor assumes a starting index of 0.
      *
      * @param range The array that describes the range.
+     * If range is null, then sets to the default range of 0..1.
      */
     public PDRange( COSArray range )
     {
-        rangeArray = range;
+        if (range == null) {
+            rangeArray = new COSArray();
+            rangeArray.add( new COSFloat( 0.0f ) );
+            rangeArray.add( new COSFloat( 1.0f ) );
+        } else {
+            rangeArray = range;
+        }
+        startingIndex = 0;
     }
 
     /**
@@ -60,11 +69,22 @@ public class PDRange implements COSObjectable
      *
      * @param range The array that describes the index
      * @param index The range index into the array for the start of the range.
+     * If range is null, then regardless of index, sets to the default range of 0..1.
+     * @throws IllegalArgumentException if index does not correspond to a valid range.
      */
     public PDRange( COSArray range, int index )
     {
-        rangeArray = range;
-        startingIndex = index;
+        if (range == null) {
+            rangeArray = new COSArray();
+            rangeArray.add( new COSFloat( 0.0f ) );
+            rangeArray.add( new COSFloat( 1.0f ) );
+            startingIndex = 0;
+        } else if (index < 0 || 2 * index + 2 > range.size()) {
+            throw new IllegalArgumentException("index does not correspond to a valid range in the array.");
+        } else {
+            rangeArray = Objects.requireNonNull(range, "range cannot be null");
+            startingIndex = index;
+        }
     }
 
     /**

--- a/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/common/TestPDRange.java
+++ b/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/common/TestPDRange.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.pdfbox.pdmodel.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.apache.pdfbox.cos.COSArray;
+import org.apache.pdfbox.cos.COSFloat;
+import org.junit.jupiter.api.Test;
+
+class TestPDRange {
+    
+    @Test
+    void testNullRange()
+    {
+        PDRange pdRange1 = new PDRange( null );
+        assertEquals( pdRange1.getMin(), 0.0f );
+        assertEquals( pdRange1.getMax(), 1.0f );
+
+        PDRange pdRange2 = new PDRange( null, 0 );
+        assertEquals( pdRange2.getMin(), 0.0f );
+        assertEquals( pdRange2.getMax(), 1.0f );
+    }
+
+    @Test
+    void testInvalidIndex()
+    {
+        COSArray cosArray = new COSArray();
+        cosArray.add( new COSFloat( 0.0f ) );
+        cosArray.add( new COSFloat( 1.0f ) );
+        cosArray.add( new COSFloat( 2.0f ) );
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            new PDRange( cosArray, -1 );
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            new PDRange( cosArray, 1 );
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            new PDRange( cosArray, 2 );
+        });
+    }
+}


### PR DESCRIPTION
This PR intends to provide suitable guards against invalid arguments to the `PDRange` constructors.

The first case is when the `COSArray range` parameter is given the `null` value.
Here, the `null` value is directly saved to the `rangeArray` variable, and cannot be set to a non-null value using any other public method.
Hence, I argue that this case should be guarded against in the constructor, either by throwing an exception (for example, using the `Objects.requireNonNull` method) or by setting the range to a default range (as implemented in my commit using 0..1).

The second case is when the `index` parameter leads to invalid indices for the range's minimum and maximum values.
Again, the provided `index`'s value is directly saved to the `startingIndex` variable, and cannot by changed via any public method.
Moreover, no public method could lengthen the `rangeArray`.
The methods `setMin` and `setMax` do not check the validity of the indices `2*startingIndex` and `2*startingIndex+1`, which could throw exceptions down the line.
Thus, I argue that this case also should be handled here, either by throwing an exception (as implemented in my commit using `IllegalArgumentException`) or by using a default index (such as 0).