### PR TITLE
Guard Filter.decode against empty filterList

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/filter/Filter.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/filter/Filter.java
@@ -206,6 +206,9 @@ public abstract class Filter
     {
         int length = parameters.getInt(COSName.LENGTH,
                 RandomAccessReadBuffer.DEFAULT_CHUNK_SIZE_4KB);
+        if (filterList.size() == 0) {
+            throw new IllegalArgumentException("Empty filterList");
+        }
         if (filterList.size() > 1)
         {
             Set<Filter> filterSet = new HashSet<>(filterList);

--- a/pdfbox/src/test/java/org/apache/pdfbox/filter/TestFilters.java
+++ b/pdfbox/src/test/java/org/apache/pdfbox/filter/TestFilters.java
@@ -17,6 +17,7 @@
 package org.apache.pdfbox.filter;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -24,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
+import java.util.ArrayList;
 import java.util.Random;
 
 import org.apache.pdfbox.Loader;
@@ -188,5 +190,12 @@ class TestFilters
         assertArrayEquals(original, decoded.toByteArray(),
                 "Data that is encoded and then decoded through " + filter.getClass()
                         + " does not match the original data");
+    }
+
+    @Test
+    void testEmptyFilterList() throws Exception {
+        assertThrows(IllegalArgumentException.class, () -> {
+            Filter.decode(null, new ArrayList(), new COSDictionary(), null, null);
+        });
     }
 }


### PR DESCRIPTION
If an empty list is provided to the `Filter.decode` static method, then a `NullPointerException` is thrown just before the return statement, where `randomAccessWriteBuffer` has not been set.
The error message is thus of little help in debugging, as it gives no indication that the `filterList` argument is at fault here. This commit adds a guard to throw an `IllegalArgumentException` before the main execution to provide a more informative error trace.