### PR TITLE
Use computed font height as font size

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/form/AppearanceGeneratorHelper.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/form/AppearanceGeneratorHelper.java
@@ -914,6 +914,11 @@ class AppearanceGeneratorHelper
                 }
 
                 float heightBasedFontSize = contentRect.getHeight() / height * yScalingFactor;
+
+                // in case that we have empty content
+                if (widthBasedFontSize <= 0) {
+                    return heightBasedFontSize;
+                }
                 
                 return Math.min(heightBasedFontSize, widthBasedFontSize);
             }


### PR DESCRIPTION
Use computed font height as font size in case that form field has dynamic font size (0) and its value is empty so width can't be used