### PR TITLE
suppress warnings for octals, omit trailing blanks

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/encoding/BuiltInEncoding.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/encoding/BuiltInEncoding.java
@@ -36,7 +36,7 @@ public class BuiltInEncoding extends Encoding
     {
         codeToName.forEach(this::add);
     }
-    
+
     @Override
     public COSBase getCOSObject()
     {

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/encoding/DictionaryEncoding.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/encoding/DictionaryEncoding.java
@@ -61,7 +61,7 @@ public class DictionaryEncoding extends Encoding
         {
             throw new IllegalArgumentException("Invalid encoding: " + baseEncoding);
         }
-        
+
         codeToName.putAll(this.baseEncoding.codeToName);
         inverted.putAll(this.baseEncoding.inverted);
         applyDifferences();
@@ -78,7 +78,7 @@ public class DictionaryEncoding extends Encoding
         baseEncoding = null;
         applyDifferences();
     }
-    
+
     /**
      * Creates a new DictionaryEncoding from a PDF.
      *
@@ -116,7 +116,7 @@ public class DictionaryEncoding extends Encoding
                 {
                     // triggering this error indicates a bug in PDFBox. Every font should always have
                     // a built-in encoding, if not, we parsed it incorrectly.
-                    throw new IllegalArgumentException("Symbolic fonts must have a built-in " + 
+                    throw new IllegalArgumentException("Symbolic fonts must have a built-in " +
                                                        "encoding");
                 }
             }
@@ -156,7 +156,7 @@ public class DictionaryEncoding extends Encoding
 
     /**
      * Returns the base encoding. Will be null for Type 3 fonts.
-     * 
+     *
      * @return the base encoding or null
      */
     public Encoding getBaseEncoding()
@@ -166,7 +166,7 @@ public class DictionaryEncoding extends Encoding
 
     /**
      * Returns the Differences array.
-     * 
+     *
      * @return a map containing all differences
      */
     public Map<Integer, String> getDifferences()

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/encoding/Encoding.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/encoding/Encoding.java
@@ -25,7 +25,7 @@ import org.apache.pdfbox.pdmodel.common.COSObjectable;
 
 /**
  * A PostScript encoding vector, maps character codes to glyph names.
- * 
+ *
  * @author Ben Litchfield
  */
 public abstract class Encoding implements COSObjectable
@@ -75,7 +75,7 @@ public abstract class Encoding implements COSObjectable
 
     /**
      * Returns an unmodifiable view of the code -&gt; name mapping.
-     * 
+     *
      * @return the code -&gt; name map
      */
     public Map<Integer, String> getCodeToNameMap()
@@ -97,9 +97,9 @@ public abstract class Encoding implements COSObjectable
     /**
      * This will add a character encoding. An already existing mapping is preserved when creating
      * the reverse mapping. Should only be used during construction of the class.
-     * 
+     *
      * @see #overwrite(int, String)
-     * 
+     *
      * @param code character code
      * @param name PostScript glyph name
      */
@@ -136,7 +136,7 @@ public abstract class Encoding implements COSObjectable
 
     /**
      * Determines if the encoding has a mapping for the given name value.
-     * 
+     *
      * @param name PostScript glyph name
      * @return true if the encoding has a mapping for the given name value
      */
@@ -147,10 +147,10 @@ public abstract class Encoding implements COSObjectable
 
     /**
      * Determines if the encoding has a mapping for the given code value.
-     * 
+     *
      * @param code character code
      * @return if the encoding has a mapping for the given code value
-     * 
+     *
      */
     public boolean contains(int code)
     {
@@ -159,23 +159,18 @@ public abstract class Encoding implements COSObjectable
 
     /**
      * This will take a character code and get the name from the code.
-     * 
+     *
      * @param code character code
-     * @return PostScript glyph name
+     * @return PostScript glyph name, or ".notdef" when not found.
      */
     public String getName(int code)
     {
-       String name = codeToName.get(code);
-       if (name != null)
-       {
-          return name;
-       }
-       return ".notdef";
+       return codeToName.getOrDefault(code, ".notdef");
     }
 
     /**
      * Returns the name of this encoding.
-     * 
+     *
      * @return the name of the encoding
      */
     public abstract String getEncodingName();

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/encoding/GlyphList.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/encoding/GlyphList.java
@@ -38,10 +38,10 @@ public final class GlyphList
 
     // Adobe Glyph List (AGL)
     private static final GlyphList DEFAULT = load("glyphlist.txt", 4281);
-    
+
     // Zapf Dingbats has its own glyph list
     private static final GlyphList ZAPF_DINGBATS = load("zapfdingbats.txt",201);
-    
+
     /**
      * Loads a glyph list from disk.
      */
@@ -65,7 +65,7 @@ public final class GlyphList
 
     /**
      * Returns the Adobe Glyph List (AGL).
-     * 
+     *
      * @return the Adobe glyph list
      */
     public static GlyphList getAdobeGlyphList()
@@ -75,7 +75,7 @@ public final class GlyphList
 
     /**
      * Returns the Zapf Dingbats glyph list.
-     * 
+     *
      * @return the Zapf Dingbats glyph list
      */
     public static GlyphList getZapfDingbats()
@@ -86,7 +86,7 @@ public final class GlyphList
     // read-only mappings, never modified outside GlyphList's constructor
     private final Map<String, String> nameToUnicode;
     private final Map<String, String> unicodeToName;
-    
+
     // additional read/write cache for uniXXXX names
     private final Map<String, String> uniNameToUnicodeCache = new ConcurrentHashMap<>();
 
@@ -154,11 +154,11 @@ public final class GlyphList
                     nameToUnicode.put(name, string);
 
                     // reverse mapping
-                    // PDFBOX-3884: take the various standard encodings as canonical, 
+                    // PDFBOX-3884: take the various standard encodings as canonical,
                     // e.g. tilde over ilde
                     final boolean forceOverride =
                           WinAnsiEncoding.INSTANCE.contains(name) ||
-                          MacRomanEncoding.INSTANCE.contains(name) || 
+                          MacRomanEncoding.INSTANCE.contains(name) ||
                           MacExpertEncoding.INSTANCE.contains(name) ||
                           SymbolEncoding.INSTANCE.contains(name) ||
                           ZapfDingbatsEncoding.INSTANCE.contains(name);
@@ -221,7 +221,7 @@ public final class GlyphList
         {
             return unicode;
         }
-        
+
         // separate read/write cache for thread safety
         unicode = uniNameToUnicodeCache.get(name);
         if (unicode == null)

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/encoding/MacExpertEncoding.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/encoding/MacExpertEncoding.java
@@ -27,6 +27,7 @@ public class MacExpertEncoding extends Encoding
     /**
      * Table of octal character codes and their corresponding names.
      */
+    @SuppressWarnings("OctalInteger")
     private static final Object[][] MAC_EXPERT_ENCODING_TABLE = {
         {0276, "AEsmall"},
         {0207, "Aacutesmall"},
@@ -194,7 +195,7 @@ public class MacExpertEncoding extends Encoding
         {060, "zerooldstyle"},
         {0342, "zerosuperior"}
     };
-    
+
     /**
      * Singleton instance of this class.
      */
@@ -210,7 +211,7 @@ public class MacExpertEncoding extends Encoding
             add((Integer) encodingEntry[CHAR_CODE], encodingEntry[CHAR_NAME].toString());
         }
     }
-    
+
     @Override
     public COSBase getCOSObject()
     {

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/encoding/MacOSRomanEncoding.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/encoding/MacOSRomanEncoding.java
@@ -27,7 +27,9 @@ public class MacOSRomanEncoding extends MacRomanEncoding
     /**
      * Table of octal character codes and their corresponding names
      * on top of {@link MacRomanEncoding}.
+     * ToDo are these really octals?? leading 0 seems to be missing
      */
+    @SuppressWarnings("OctalInteger")
     private static final Object[][] MAC_OS_ROMAN_ENCODING_TABLE = {
             {255, "notequal"},
             {260, "infinity"},
@@ -44,9 +46,9 @@ public class MacOSRomanEncoding extends MacRomanEncoding
             {306, "Delta"},
             {327, "lozenge"},
             {333, "Euro"},
-            {360, "apple"}    
+            {360, "apple"}
     };
-    
+
     /**
      * Singleton instance of this class.
      *

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/encoding/MacRomanEncoding.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/encoding/MacRomanEncoding.java
@@ -29,6 +29,7 @@ public class MacRomanEncoding extends Encoding
     /**
      * Table of octal character codes and their corresponding names.
      */
+    @SuppressWarnings("OctalInteger")
     private static final Object[][] MAC_ROMAN_ENCODING_TABLE = {
             {0101, "A"},
             {0256, "AE"},
@@ -240,7 +241,7 @@ public class MacRomanEncoding extends Encoding
             // adding an additional mapping as defined in Appendix D of the pdf spec
             {0312, "nbspace"}
     };
-    
+
     /**
      * Singleton instance of this class.
      *
@@ -258,7 +259,7 @@ public class MacRomanEncoding extends Encoding
             add((Integer) encodingEntry[CHAR_CODE], encodingEntry[CHAR_NAME].toString());
         }
     }
-    
+
     @Override
     public COSBase getCOSObject()
     {

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/encoding/StandardEncoding.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/encoding/StandardEncoding.java
@@ -29,6 +29,7 @@ public class StandardEncoding extends Encoding
     /**
      * Table of octal character codes and their corresponding names.
      */
+    @SuppressWarnings("OctalInteger")
     private static final Object[][] STANDARD_ENCODING_TABLE = {
             {0101, "A"},
             {0341, "AE"},

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/encoding/SymbolEncoding.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/encoding/SymbolEncoding.java
@@ -27,6 +27,7 @@ public class SymbolEncoding extends Encoding
     /**
      * Table of octal character codes and their corresponding names.
      */
+    @SuppressWarnings("OctalInteger")
     private static final Object[][] SYMBOL_ENCODING_TABLE = {
         {0101, "Alpha"},
         {0102, "Beta"},
@@ -216,9 +217,9 @@ public class SymbolEncoding extends Encoding
         {0303, "weierstrass"},
         {0170, "xi"},
         {0060, "zero"},
-        {0172, "zeta"}       
+        {0172, "zeta"}
     };
-    
+
     /**
      * Singleton instance of this class.
      */
@@ -234,7 +235,7 @@ public class SymbolEncoding extends Encoding
             add((Integer) encodingEntry[CHAR_CODE], encodingEntry[CHAR_NAME].toString());
         }
     }
-    
+
     @Override
     public COSBase getCOSObject()
     {

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/encoding/WinAnsiEncoding.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/encoding/WinAnsiEncoding.java
@@ -21,7 +21,7 @@ import org.apache.pdfbox.cos.COSName;
 
 /**
  * This the win ansi encoding.
- * 
+ *
  * @author Ben Litchfield
  */
 public class WinAnsiEncoding extends Encoding
@@ -29,6 +29,7 @@ public class WinAnsiEncoding extends Encoding
     /**
      * Table of octal character codes and their corresponding names.
      */
+    @SuppressWarnings("OctalInteger")
     private static final Object[][] WIN_ANSI_ENCODING_TABLE = {
             {0101, "A"},
             {0306, "AE"},
@@ -253,7 +254,7 @@ public class WinAnsiEncoding extends Encoding
 
     /**
      * Singleton instance of this class.
-     * 
+     *
      * @since Apache PDFBox 1.3.0
      */
     public static final WinAnsiEncoding INSTANCE = new WinAnsiEncoding();

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/encoding/ZapfDingbatsEncoding.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/encoding/ZapfDingbatsEncoding.java
@@ -27,6 +27,7 @@ public class ZapfDingbatsEncoding extends Encoding
     /**
      * Table of octal character codes and their corresponding names.
      */
+    @SuppressWarnings("OctalInteger")
     private static final Object[][] ZAPFDINGBATS_ENCODING_TABLE = {
         {040, "space"},
         {041, "a1"},
@@ -217,7 +218,7 @@ public class ZapfDingbatsEncoding extends Encoding
         {0375, "a190"},
         {0376, "a191"}
     };
-    
+
     /**
      * Singleton instance of this class.
      */
@@ -233,7 +234,7 @@ public class ZapfDingbatsEncoding extends Encoding
             add((Integer) encodingEntry[CHAR_CODE], encodingEntry[CHAR_NAME].toString());
         }
     }
-    
+
     @Override
     public COSBase getCOSObject()
     {


### PR DESCRIPTION
- suppress warnings on octal constants in Encoding-tables
- ToDo potential error: missing leading 0 in MacOSRomanEncoding.java
- drop trailing blanks