### PR TITLE
Fix containers inefficiencies in Type1CharString.java, COSWriterCompressionPool.java, and ShadedTriangle.java

### DIFF
--- a/fontbox/src/main/java/org/apache/fontbox/cff/Type1CharString.java
+++ b/fontbox/src/main/java/org/apache/fontbox/cff/Type1CharString.java
@@ -168,6 +168,7 @@ public class Type1CharString
             // indicates an invalid charstring
             LOG.warn("Unknown charstring command in glyph {} of font {}", glyphName, fontName);
             numbers.clear();
+            return;
         }
         switch(type1KeyWord)
         {

--- a/fontbox/src/main/java/org/apache/fontbox/cff/Type1CharString.java
+++ b/fontbox/src/main/java/org/apache/fontbox/cff/Type1CharString.java
@@ -150,9 +150,7 @@ public class Type1CharString
         type1Sequence.forEach(obj -> {
             if (obj instanceof CharStringCommand)
             {
-                List<Number> results = handleType1Command(numbers, (CharStringCommand) obj);
-                numbers.clear();
-                numbers.addAll(results);
+                handleType1Command(numbers, (CharStringCommand) obj);
             }
             else
             {
@@ -161,7 +159,7 @@ public class Type1CharString
         });
     }
 
-    private List<Number> handleType1Command(List<Number> numbers, CharStringCommand command)
+    private void handleType1Command(List<Number> numbers, CharStringCommand command)
     {
         commandCount++;
         Type1KeyWord type1KeyWord = command.getType1KeyWord();
@@ -169,7 +167,7 @@ public class Type1CharString
         {
             // indicates an invalid charstring
             LOG.warn("Unknown charstring command in glyph {} of font {}", glyphName, fontName);
-            return Collections.emptyList();
+            numbers.clear();
         }
         switch(type1KeyWord)
         {
@@ -298,11 +296,10 @@ public class Type1CharString
 
                 float result = a / b;
 
-                List<Number> list = new ArrayList<>(numbers);
-                list.remove(list.size() - 1);
-                list.remove(list.size() - 1);
-                list.add(result);
-                return list;
+                numbers.remove(numbers.size() - 1);
+                numbers.remove(numbers.size() - 1);
+                numbers.add(result);
+                return;
             }
             break;
         case HSTEM:
@@ -325,7 +322,7 @@ public class Type1CharString
             // indicates a PDFBox bug
             throw new IllegalArgumentException("Unhandled command: " + type1KeyWord);
         }
-        return Collections.emptyList();
+        numbers.clear();
     }
 
     /**

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdfwriter/compress/COSWriterCompressionPool.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdfwriter/compress/COSWriterCompressionPool.java
@@ -21,6 +21,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
 
 import org.apache.pdfbox.pdfparser.PDFXRefStream;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -53,7 +55,7 @@ public class COSWriterCompressionPool
     // A list containing all objects, that may be appended to an object stream.
     private final List<COSObjectKey> objectStreamObjects = new ArrayList<>();
     // A list of all direct objects
-    private final List<COSBase> allDirectObjects = new ArrayList<>();
+    private final Set<COSBase> allDirectObjects = new HashSet<>();
 
     /**
      * <p>

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/shading/ShadedTriangle.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/shading/ShadedTriangle.java
@@ -100,13 +100,18 @@ class ShadedTriangle
      */
     private int calcDeg(Point2D[] p)
     {
-        Set<Point> set = new HashSet<>();
-        for (Point2D itp : p)
-        {
-            Point np = new Point((int) Math.round(itp.getX() * 1000), (int) Math.round(itp.getY() * 1000));
-            set.add(np);
+        if ((int) p[0].getX() * 1000 == (int) p[1].getX() && (int) p[0].getY() * 1000 == (int) p[1].getY()) {
+            if ((int) p[0].getX() * 1000 == (int) p[2].getX() && (int) p[0].getY() * 1000 == (int) p[2].getY()) {
+                return 1;
+            } else {
+                return 2;
+            }
+        } else if ((int) p[0].getX() * 1000 == (int) p[2].getX() && (int) p[0].getY() * 1000 == (int) p[2].getY()
+                || (int) p[1].getX() * 1000 == (int) p[2].getX() && (int) p[1].getY() * 1000 == (int) p[2].getY()) {
+            return 2;
+        } else {
+            return 3;
         }
-        return set.size();
     }
 
     public int getDeg()


### PR DESCRIPTION
Hi,

We find that there exist container inefficiencies in Type1CharString.java, COSWriterCompressionPool.java, and ShadedTriangle.java.

In particular, at line 301 of Type1CharString.java, the object `list` copies the `numbers` and removes the last two elements for calculation purposes before adding the result, which is then returned by the method `handleType1Command`. Apart from this scenario, method `handleType1Command` returns `Collections.emptyList()`. However, at lines 154 and 155, after the the invocation of `handleType1Command`, the `numbers` object is cleared, and the `results` object are copied to the `numbers` object using the `addAll` method. This process involves redundant copying and clearing operations.

For COSWriterCompressionPool.java, at the line 56, the created `List` object `allDirectObjects` is only used for `contains` and `add` operations within the `addElements` method. Such usage scenarios are more suitable for a `Set` container with lower complexity.

For ShadedTriangle.java, according to the prurpose of method calcDeg, there is too expensive to create objects and pass them to a `Set` to obtain the count of unique elements and then returning the count.

We discovered the above containers inefficiencies by our tool cinst. The patch is submitted. Could you please check and accept it? We have tested the patch on our PC. The patched program works well.