### PR TITLE
Improve performance of FileSystemFontProvider.scanFonts()

### DIFF
--- a/fontbox/src/main/java/org/apache/fontbox/ttf/CFFTable.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/CFFTable.java
@@ -20,6 +20,8 @@ package org.apache.fontbox.ttf;
 import java.io.IOException;
 import org.apache.fontbox.cff.CFFFont;
 import org.apache.fontbox.cff.CFFParser;
+import org.apache.pdfbox.io.RandomAccessRead;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 
 /**
  * PostScript font program (compact font format).
@@ -54,6 +56,27 @@ public class CFFTable extends TTFTable
         cffFont = parser.parse(bytes, new CFFBytesource(ttf)).get(0);
 
         initialized = true;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    void readHeaders(TrueTypeFont ttf, TTFDataStream data, FontHeaders outHeaders) throws IOException
+    {
+        try (RandomAccessRead subReader = data.createSubView(getLength()))
+        {
+            RandomAccessRead reader;
+            if (subReader != null)
+            {
+                reader = subReader;
+            }
+            else
+            {
+                assert false : "It is inefficient to read TTFDataStream into an array";
+                byte[] bytes = data.read((int)getLength());
+                reader = new RandomAccessReadBuffer(bytes);
+            }
+            new CFFParser().parseFirstSubFontROS(reader, outHeaders);
+        }
     }
 
     /**

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/FontHeaders.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/FontHeaders.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.fontbox.ttf;
+
+/**
+ * To improve performance of {@code FileSystemFontProvider.scanFonts(...)},
+ * this class is used both as a marker (to skip unused data) and as a storage for collected data.
+ * <p>
+ * Tables it needs:<ul>
+ * <li>NamingTable.TAG
+ * <li>HeaderTable.TAG
+ * <li>OS2WindowsMetricsTable.TAG
+ * <li>CFFTable.TAG (for OTF)
+ * <li>"gcid" (for non-OTF)
+ * </ul>
+ *
+ * @author Mykola Bohdiuk
+ */
+public final class FontHeaders
+{
+    static final int BYTES_GCID = 142;
+
+    private String error;
+    private String name;
+    private Integer headerMacStyle;
+    private OS2WindowsMetricsTable os2Windows;
+    private String fontFamily;
+    private String fontSubFamily;
+    private byte[] nonOtfGcid142;
+    //
+    private boolean isOTFAndPostScript;
+    private String otfRegistry;
+    private String otfOrdering;
+    private int otfSupplement;
+
+    public String getError()
+    {
+        return error;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    /**
+     * null == no HeaderTable, {@code ttf.getHeader().getMacStyle()}
+     */
+    public Integer getHeaderMacStyle()
+    {
+        return headerMacStyle;
+    }
+
+    public OS2WindowsMetricsTable getOS2Windows()
+    {
+        return os2Windows;
+    }
+
+    // only when LOGGER(FileSystemFontProvider).isTraceEnabled() tracing: FontFamily, FontSubfamily
+    public String getFontFamily()
+    {
+        return fontFamily;
+    }
+
+    public String getFontSubFamily()
+    {
+        return fontSubFamily;
+    }
+
+    public boolean isOpenTypePostScript()
+    {
+        return isOTFAndPostScript;
+    }
+
+    public byte[] getNonOtfTableGCID142()
+    {
+        return nonOtfGcid142;
+    }
+
+    public String getOtfRegistry()
+    {
+        return otfRegistry;
+    }
+
+    public String getOtfOrdering()
+    {
+        return otfOrdering;
+    }
+
+    public int getOtfSupplement()
+    {
+        return otfSupplement;
+    }
+
+    public void setError(String exception)
+    {
+        this.error = exception;
+    }
+
+    void setName(String name)
+    {
+        this.name = name;
+    }
+
+    void setHeaderMacStyle(Integer headerMacStyle)
+    {
+        this.headerMacStyle = headerMacStyle;
+    }
+
+    void setOs2Windows(OS2WindowsMetricsTable os2Windows)
+    {
+        this.os2Windows = os2Windows;
+    }
+
+    void setFontFamily(String fontFamily, String fontSubFamily)
+    {
+        this.fontFamily = fontFamily;
+        this.fontSubFamily = fontSubFamily;
+    }
+
+    void setNonOtfGcid142(byte[] nonOtfGcid142)
+    {
+        this.nonOtfGcid142 = nonOtfGcid142;
+    }
+
+    void setIsOTFAndPostScript(boolean isOTFAndPostScript)
+    {
+        this.isOTFAndPostScript = isOTFAndPostScript;
+    }
+
+    // public because CFFParser is in a different package
+    public void setOtfROS(String otfRegistry, String otfOrdering, int otfSupplement)
+    {
+        this.otfRegistry = otfRegistry;
+        this.otfOrdering = otfOrdering;
+        this.otfSupplement = otfSupplement;
+    }
+}

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/HeaderTable.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/HeaderTable.java
@@ -64,6 +64,16 @@ public class HeaderTable extends TTFTable
         super();
     }
 
+    /** {@inheritDoc} */
+    @Override
+    void readHeaders(TrueTypeFont ttf, TTFDataStream data, FontHeaders outHeaders) throws IOException
+    {
+        // 44 == 4 + 4 + 4 + 4 + 2 + 2 + 2*8 + 4*2, see read()
+        data.seek(data.getCurrentPosition() + 44);
+        macStyle = data.readUnsignedShort();
+        outHeaders.setHeaderMacStyle(macStyle);
+    }
+
     /**
      * This will read the required data from the stream.
      *

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/RandomAccessReadDataStream.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/RandomAccessReadDataStream.java
@@ -19,9 +19,12 @@ package org.apache.fontbox.ttf;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.apache.pdfbox.io.IOUtils;
 import org.apache.pdfbox.io.RandomAccessRead;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 
 /**
  * An implementation of the TTFDataStream using RandomAccessRead as source.
@@ -30,6 +33,8 @@ import org.apache.pdfbox.io.RandomAccessRead;
  */
 class RandomAccessReadDataStream extends TTFDataStream
 {
+    private static final Log LOG = LogFactory.getLog(RandomAccessReadDataStream.class);
+
     private final long length;
     private final byte[] data;
     private int currentPosition = 0;
@@ -172,6 +177,20 @@ class RandomAccessReadDataStream extends TTFDataStream
         System.arraycopy(data, currentPosition, b, off, bytesToRead);
         currentPosition += bytesToRead;
         return bytesToRead;
+    }
+
+    @Override
+    public RandomAccessRead createSubView(long length)
+    {
+        try
+        {
+            return new RandomAccessReadBuffer(data).createView(currentPosition, length);
+        }
+        catch (IOException e)
+        {
+            LOG.warn("Could not create a SubView", e);
+            return null;
+        }
     }
 
     /**

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/RandomAccessReadUnbufferedDataStream.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/RandomAccessReadUnbufferedDataStream.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.fontbox.ttf;
+
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.pdfbox.io.RandomAccessRead;
+import org.apache.pdfbox.io.RandomAccessReadView;
+
+/**
+ * In contrast to {@link RandomAccessReadDataStream},
+ * this class doesn't pre-load {@code RandomAccessRead} into a {@code byte[]},
+ * it works with {@link RandomAccessRead} directly.
+ * 
+ * Performance: it is much faster if most of the buffer is skipped, and slower if whole buffer is read()
+ */
+class RandomAccessReadUnbufferedDataStream extends TTFDataStream
+{
+    private final long length;
+    private final RandomAccessRead randomAccessRead;
+
+    /**
+     * @throws IOException If there is a problem reading the source length.
+     */
+    RandomAccessReadUnbufferedDataStream(RandomAccessRead randomAccessRead) throws IOException
+    {
+        this.length = randomAccessRead.length();
+        this.randomAccessRead = randomAccessRead;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getCurrentPosition() throws IOException
+    {
+        return randomAccessRead.getPosition();
+    }
+
+    /**
+     * Close the underlying resources.
+     *
+     * @throws IOException If there is an error closing the resources.
+     */
+    @Override
+    public void close() throws IOException
+    {
+        randomAccessRead.close();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int read() throws IOException
+    {
+        return randomAccessRead.read();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final long readLong() throws IOException
+    {
+        return ((long) readInt() << 32) | (readInt() & 0xFFFFFFFFL);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    private int readInt() throws IOException
+    {
+        int b1 = read();
+        int b2 = read();
+        int b3 = read();
+        int b4 = read();
+        return (b1 << 24) | (b2 << 16) | (b3 << 8) | b4;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void seek(long pos) throws IOException
+    {
+        randomAccessRead.seek(pos);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException
+    {
+        return randomAccessRead.read(b, off, len);
+    }
+
+    /**
+     * Lifetime of returned InputStream is bound by {@code this} lifetime, it won't close underlying {@code RandomAccessRead}.
+     * 
+     * {@inheritDoc}
+     */
+    @Override
+    public InputStream getOriginalData() throws IOException
+    {
+        return new RandomAccessReadNonClosingInputStream(randomAccessRead.createView(0, length));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getOriginalDataSize()
+    {
+        return length;
+    }
+
+    @Override
+    public RandomAccessRead createSubView(long length)
+    {
+        try
+        {
+            return randomAccessRead.createView(randomAccessRead.getPosition(), length);
+        }
+        catch (IOException ex)
+        {
+            assert false : "Please implement " + randomAccessRead.getClass() + ".createView()";
+            return null;
+        }
+    }
+
+    private static final class RandomAccessReadNonClosingInputStream extends InputStream
+    {
+
+        private final RandomAccessReadView randomAccessRead;
+
+        public RandomAccessReadNonClosingInputStream(RandomAccessReadView randomAccessRead)
+        {
+            this.randomAccessRead = randomAccessRead;
+        }
+
+        @Override
+        public int read() throws IOException
+        {
+            return randomAccessRead.read();
+        }
+
+        @Override
+        public int read(byte[] b) throws IOException
+        {
+            return randomAccessRead.read(b);
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException
+        {
+            return randomAccessRead.read(b, off, len);
+        }
+
+        @Override
+        public long skip(long n) throws IOException
+        {
+            randomAccessRead.seek(randomAccessRead.getPosition() + n);
+            return n;
+        }
+
+        @Override
+        public void close() throws IOException
+        {
+            // WARNING: .close() will close RandomAccessReadMemoryMappedFile if this View was based on it
+//            randomAccessRead.close();
+        }
+    }
+}

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/TTCDataStream.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/TTCDataStream.java
@@ -19,6 +19,7 @@ package org.apache.fontbox.ttf;
 
 import java.io.IOException;
 import java.io.InputStream;
+import org.apache.pdfbox.io.RandomAccessRead;
 
 /**
  * A wrapper for a TTF stream inside a TTC file, does not close the underlying shared stream.
@@ -83,4 +84,9 @@ class TTCDataStream extends TTFDataStream
         return stream.getOriginalDataSize();
     }
 
+    @Override
+    public RandomAccessRead createSubView(long length)
+    {
+        return stream.createSubView(length);
+    }
 }

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/TTFDataStream.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/TTFDataStream.java
@@ -24,6 +24,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Calendar;
 import java.util.TimeZone;
+import org.apache.pdfbox.io.RandomAccessRead;
 
 /**
  * An abstract class to read a data stream.
@@ -278,6 +279,17 @@ abstract class TTFDataStream implements Closeable
      * @throws IOException If there is an error reading from the stream.
      */
     public abstract int read(byte[] b, int off, int len) throws IOException;
+
+    /**
+     * Creates a view from current position to {@code pos + length}.
+     * It can be faster than {@code read(length)} if you only need a few bytes.
+     * {@code SubView.close()} should never close {@code TTFDataStream.this}, only itself.
+     *
+     * @return A view or null (caller can use {@link #read} instead). Please close() the result
+     */
+    public RandomAccessRead createSubView(long length) {
+        return null;
+    }
 
     /**
      * Get the current position in the stream.

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/TTFParser.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/TTFParser.java
@@ -105,13 +105,29 @@ public class TTFParser
     }
 
     /**
+     * Parse a RandomAccessRead and return a TrueType font.
+     *
+     * @param randomAccessRead The RandomAccessREad to be read from. It will be closed before returning.
+     * @return TrueType font headers.
+     * @throws IOException If there is an error parsing the TrueType font.
+     */
+    public FontHeaders parseTableHeaders(RandomAccessRead randomAccessRead) throws IOException
+    {
+        try (TTFDataStream dataStream = new RandomAccessReadUnbufferedDataStream(randomAccessRead))
+        {
+            return parseTableHeaders(dataStream);
+            // dataStream closes randomAccessRead
+        }
+    }
+
+    /**
      * Parse a file and get a true type font.
      *
      * @param raf The TTF file.
      * @return A TrueType font.
      * @throws IOException If there is an error parsing the TrueType font.
      */
-    TrueTypeFont parse(TTFDataStream raf) throws IOException
+    private TrueTypeFont createFontWithTables(TTFDataStream raf) throws IOException
     {
         TrueTypeFont font = newFont(raf);
         font.setVersion(raf.read32Fixed());
@@ -140,7 +156,12 @@ public class TTFParser
                 }
             }
         }
-        // parse tables
+        return font;
+    }
+
+    TrueTypeFont parse(TTFDataStream raf) throws IOException
+    {
+        TrueTypeFont font = createFontWithTables(raf);
         parseTables(font);
         return font;
     }
@@ -225,6 +246,81 @@ public class TTFParser
         {
             throw new IOException("'cmap' table is mandatory");
         }
+    }
+
+    /**
+     * Based on {@link #parseTables()}.
+     * Parse all table headers and check if all needed tables are present.
+     * 
+     * This method can be optimized further by skipping unused portions inside each individual table parser
+     *
+     * @param font the TrueTypeFont instance holding the parsed data.
+     * @throws IOException If there is an error parsing the TrueType font.
+     */
+    FontHeaders parseTableHeaders(TTFDataStream raf) throws IOException
+    {
+        FontHeaders outHeaders = new FontHeaders();
+        try (TrueTypeFont font = createFontWithTables(raf))
+        {
+            font.readTableHeaders(NamingTable.TAG, outHeaders); // calls NamingTable.readHeaders();
+            font.readTableHeaders(HeaderTable.TAG, outHeaders); // calls HeaderTable.readHeaders();
+
+            // only these 5 are used
+            //   sFamilyClass = os2WindowsMetricsTable.getFamilyClass();
+            //   usWeightClass = os2WindowsMetricsTable.getWeightClass();
+            //   ulCodePageRange1 = (int) os2WindowsMetricsTable.getCodePageRange1();
+            //   ulCodePageRange2 = (int) os2WindowsMetricsTable.getCodePageRange2();
+            //   panose = os2WindowsMetricsTable.getPanose();
+            outHeaders.setOs2Windows(font.getOS2Windows());
+
+            boolean isOTFAndPostScript;
+            if (font instanceof OpenTypeFont && ((OpenTypeFont) font).isPostScript())
+            {
+                isOTFAndPostScript = true;
+                if (((OpenTypeFont) font).isSupportedOTF())
+                {
+                    font.readTableHeaders(CFFTable.TAG, outHeaders); // calls CFFTable.readHeaders();
+                }
+            }
+            else if (!(font instanceof OpenTypeFont) && font.tables.containsKey(CFFTable.TAG))
+            {
+                outHeaders.setError("True Type fonts using CFF outlines are not supported");
+                return outHeaders;
+            }
+            else
+            {
+                isOTFAndPostScript = false;
+                TTFTable gcid = font.getTableMap().get("gcid");
+                if (gcid != null && gcid.getLength() >= FontHeaders.BYTES_GCID)
+                {
+                    outHeaders.setNonOtfGcid142(font.getTableNBytes(gcid, FontHeaders.BYTES_GCID));
+                }
+            }
+            outHeaders.setIsOTFAndPostScript(isOTFAndPostScript);
+
+            // list taken from parseTables(), detect them, but don't spend time parsing
+            final String[] mandatoryTables = {
+                HeaderTable.TAG,
+                HorizontalHeaderTable.TAG,
+                MaximumProfileTable.TAG,
+                isEmbedded ? null : PostScriptTable.TAG, // in an embedded font this table is optional
+                isOTFAndPostScript ? null : IndexToLocationTable.TAG,
+                isOTFAndPostScript ? null : GlyphTable.TAG,
+                isEmbedded ? null : NamingTable.TAG,
+                HorizontalMetricsTable.TAG,
+                isEmbedded ? null : CmapTable.TAG,
+            };
+
+            for (String tag : mandatoryTables)
+            {
+                if (tag != null && !font.tables.containsKey(tag))
+                {
+                    outHeaders.setError("'" + tag + "' table is mandatory");
+                    return outHeaders;
+                }
+            }
+        }
+        return outHeaders;
     }
 
     protected boolean allowCFF()

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/TTFTable.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/TTFTable.java
@@ -126,4 +126,16 @@ public class TTFTable
     void read(TrueTypeFont ttf, TTFDataStream data) throws IOException
     {
     }
+    
+    /**
+     * This will read required headers from the stream into outHeaders.
+     * 
+     * @param ttf The font that is being read.
+     * @param data The stream to read the data from.
+     * @param outHeaders The class to write the data to.
+     * @throws IOException If there is an error reading the data.
+     */
+    void readHeaders(TrueTypeFont ttf, TTFDataStream data, FontHeaders outHeaders) throws IOException
+    {
+    }
 }

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/TrueTypeCollection.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/TrueTypeCollection.java
@@ -47,7 +47,7 @@ public class TrueTypeCollection implements Closeable
      */
     public TrueTypeCollection(File file) throws IOException
     {
-        this(new RandomAccessReadBufferedFile(file), true);
+        this(createBufferedDataStream(new RandomAccessReadBufferedFile(file), true));
     }
 
     /**
@@ -58,7 +58,7 @@ public class TrueTypeCollection implements Closeable
      */
     public TrueTypeCollection(InputStream stream) throws IOException
     {
-        this(new RandomAccessReadBuffer(stream), false);
+        this(createBufferedDataStream(new RandomAccessReadBuffer(stream), false));
     }
 
     /**
@@ -66,21 +66,12 @@ public class TrueTypeCollection implements Closeable
      *
      * @param randomAccessRead
      * @param closeAfterReading {@code true} to close randomAccessRead
+     * @param buffered {@code true} to use {@link RandomAccessReadDataStream}, {@code false} to use {@link RandomAccessReadUnbufferedDataStream}
      * @throws IOException If the font could not be parsed.
      */
-    private TrueTypeCollection(RandomAccessRead randomAccessRead, boolean closeAfterReading) throws IOException
+    private TrueTypeCollection(TTFDataStream stream) throws IOException
     {
-        try
-        {
-            this.stream = new RandomAccessReadDataStream(randomAccessRead);
-        }
-        finally
-        {
-            if (closeAfterReading)
-            {
-                IOUtils.closeQuietly(randomAccessRead);
-            }
-        }
+        this.stream = stream;
 
         // TTC header
         String tag = stream.readTag();
@@ -107,12 +98,27 @@ public class TrueTypeCollection implements Closeable
             int ulDsigOffset = stream.readUnsignedShort();
         }
     }
-    
+
+    private static TTFDataStream createBufferedDataStream(RandomAccessRead randomAccessRead, boolean closeAfterReading) throws IOException
+    {
+        try
+        {
+            return new RandomAccessReadDataStream(randomAccessRead);
+        }
+        finally
+        {
+            if (closeAfterReading)
+            {
+                IOUtils.closeQuietly(randomAccessRead);
+            }
+        }
+    }
+
     /**
      * Run the callback for each TT font in the collection.
      * 
      * @param trueTypeFontProcessor the object with the callback method.
-     * @throws IOException if something went wrong when calling the TrueTypeFontProcessor
+     * @throws IOException if something went wrong when parsing any font or calling the TrueTypeFontProcessor
      */
     public void processAllFonts(TrueTypeFontProcessor trueTypeFontProcessor) throws IOException
     {
@@ -122,8 +128,37 @@ public class TrueTypeCollection implements Closeable
             trueTypeFontProcessor.process(font);
         }
     }
-    
+
+    /**
+     * Run the callback for each TT font in the collection.
+     * 
+     * @param trueTypeFontProcessor the object with the callback method.
+     * @throws IOException if something went wrong when parsing any font
+     */
+    public static void processAllFontHeaders(File ttcFile, TrueTypeFontHeadersProcessor trueTypeFontProcessor) throws IOException
+    {
+        try (
+                RandomAccessRead read = new RandomAccessReadBufferedFile(ttcFile);
+                TTFDataStream stream = new RandomAccessReadUnbufferedDataStream(read);
+                TrueTypeCollection ttc = new TrueTypeCollection(stream)
+        )
+        {
+            for (int i = 0; i < ttc.numFonts; i++)
+            {
+                TTFParser parser = ttc.createFontParserAtIndexAndSeek(i);
+                FontHeaders headers = parser.parseTableHeaders(new TTCDataStream(ttc.stream));
+                trueTypeFontProcessor.process(headers);
+            }
+        }
+    }
+
     private TrueTypeFont getFontAtIndex(int idx) throws IOException
+    {
+        TTFParser parser = createFontParserAtIndexAndSeek(idx);
+        return parser.parse(new TTCDataStream(stream));
+    }
+
+    private TTFParser createFontParserAtIndexAndSeek(int idx) throws IOException
     {
         stream.seek(fontOffsets[idx]);
         TTFParser parser;
@@ -136,7 +171,7 @@ public class TrueTypeCollection implements Closeable
             parser = new TTFParser(false);
         }
         stream.seek(fontOffsets[idx]);
-        return parser.parse(new TTCDataStream(stream));
+        return parser;
     }
 
     /**
@@ -167,7 +202,16 @@ public class TrueTypeCollection implements Closeable
     {
         void process(TrueTypeFont ttf) throws IOException;
     }
-    
+
+    /**
+     * Implement the callback method to call {@link TrueTypeCollection#processAllFontHeaders(TrueTypeFontHeadersProcessor)}.
+     */
+    @FunctionalInterface
+    public interface TrueTypeFontHeadersProcessor
+    {
+        void process(FontHeaders ttf);
+    }
+
     @Override
     public void close() throws IOException
     {

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/FileSystemFontProvider.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/FileSystemFontProvider.java
@@ -37,9 +37,7 @@ import java.util.zip.CRC32;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.fontbox.FontBoxFont;
-import org.apache.fontbox.cff.CFFCIDFont;
-import org.apache.fontbox.cff.CFFFont;
-import org.apache.fontbox.ttf.NamingTable;
+import org.apache.fontbox.ttf.FontHeaders;
 import org.apache.fontbox.ttf.OS2WindowsMetricsTable;
 import org.apache.fontbox.ttf.OTFParser;
 import org.apache.fontbox.ttf.OpenTypeFont;
@@ -59,6 +57,12 @@ import org.apache.pdfbox.io.RandomAccessReadBufferedFile;
 final class FileSystemFontProvider extends FontProvider
 {
     private static final Log LOG = LogFactory.getLog(FileSystemFontProvider.class);
+    /**
+     * This option changes publicly visible behaviour: ".pdfbox.cache" file will have hash="-" for all files.
+     * After implementing {@link FontHeaders}, parsing font headers is faster than checksumming anyway.
+     */
+    private static final boolean SKIP_CHECKSUMS = "true".equals(System.getProperty("pdfbox.fontcache.skipchecksums"));
+    private static final String CHECKSUM_PLACEHOLDER = "-";
     
     private final List<FSFontInfo> fontInfoList = new ArrayList<>();
     private final FontCache cache;
@@ -315,7 +319,7 @@ final class FileSystemFontProvider extends FontProvider
         String hash;
         try
         {
-            hash = computeHash(Files.newInputStream(file.toPath()));
+            hash = SKIP_CHECKSUMS ? CHECKSUM_PLACEHOLDER : computeHash(Files.newInputStream(file.toPath()));
         }
         catch (IOException ex)
         {
@@ -382,25 +386,18 @@ final class FileSystemFontProvider extends FontProvider
 
         for (File file : files)
         {
-            try
+            String filePath = file.getPath().toLowerCase();
+            if (filePath.endsWith(".ttf") || filePath.endsWith(".otf"))
             {
-                String filePath = file.getPath().toLowerCase();
-                if (filePath.endsWith(".ttf") || filePath.endsWith(".otf"))
-                {
-                    addTrueTypeFont(file);
-                }
-                else if (filePath.endsWith(".ttc") || filePath.endsWith(".otc"))
-                {
-                    addTrueTypeCollection(file);
-                }
-                else if (filePath.endsWith(".pfb"))
-                {
-                    addType1Font(file);
-                }
+                addTrueTypeFont(file);
             }
-            catch (IOException e)
+            else if (filePath.endsWith(".ttc") || filePath.endsWith(".otc"))
             {
-                LOG.warn("Error parsing font " + file.getPath(), e);
+                addTrueTypeCollection(file);
+            }
+            else if (filePath.endsWith(".pfb"))
+            {
+                addType1Font(file);
             }
         }
     }
@@ -537,6 +534,11 @@ final class FileSystemFontProvider extends FontProvider
         {
             try (BufferedReader reader = new BufferedReader(new FileReader(diskCacheFile)))
             {
+                // consequent lines usually share the same font file (e.g. "Courier", "Courier-Bold", "Courier-Oblique").
+                // unused if SKIP_CHECKSUMS
+                File lastFile = null;
+                String lastHash = null;
+                //
                 String line;
                 while ((line = reader.readLine()) != null)
                 {
@@ -599,22 +601,35 @@ final class FileSystemFontProvider extends FontProvider
                     }
                     if (fontFile.exists())
                     {
-                        boolean keep = false;
                         // if the file exists, find out whether it's the same file.
                         // first check whether time is different and if yes, whether hash is different
-                        if (fontFile.lastModified() != lastModified)
+                        boolean keep = fontFile.lastModified() == lastModified;
+                        if (!keep && !SKIP_CHECKSUMS)
                         {
-                            String newHash = computeHash(Files.newInputStream(fontFile.toPath()));
-                            if (newHash.equals(hash))
+                            String newHash;
+                            if (hash.equals(lastHash) && fontFile.equals(lastFile))
+                            {
+                                newHash = lastHash; // already computed
+                            }
+                            else
+                            {
+                                try
+                                {
+                                    newHash = computeHash(Files.newInputStream(fontFile.toPath()));
+                                    lastFile = fontFile;
+                                    lastHash = newHash;
+                                }
+                                catch (IOException ex)
+                                {
+                                    LOG.debug("Error reading font file " + fontFile.getAbsolutePath(), ex);
+                                    newHash = "<err>";
+                                }
+                            }
+                            if (hash.equals(newHash))
                             {
                                 keep = true;
                                 lastModified = fontFile.lastModified();
-                                hash = newHash;
                             }
-                        }
-                        else
-                        {
-                            keep = true;
                         }
                         if (keep)
                         {
@@ -656,11 +671,13 @@ final class FileSystemFontProvider extends FontProvider
     /**
      * Adds a TTC or OTC to the file cache. To reduce memory, the parsed font is not cached.
      */
-    private void addTrueTypeCollection(final File ttcFile) throws IOException
+    private void addTrueTypeCollection(final File ttcFile)
     {
-        try (TrueTypeCollection ttc = new TrueTypeCollection(ttcFile))
+        try
         {
-            ttc.processAllFonts(ttf -> addTrueTypeFontImpl(ttf, ttcFile));
+            String hash = SKIP_CHECKSUMS ? CHECKSUM_PLACEHOLDER : computeHash(Files.newInputStream(ttcFile.toPath()));
+            TrueTypeCollection.processAllFontHeaders(ttcFile,
+                    ttf -> addTrueTypeFontImpl(ttf, ttcFile, hash));
         }
         catch (IOException e)
         {
@@ -672,25 +689,25 @@ final class FileSystemFontProvider extends FontProvider
     /**
      * Adds an OTF or TTF font to the file cache. To reduce memory, the parsed font is not cached.
      */
-    private void addTrueTypeFont(File ttfFile) throws IOException
+    private void addTrueTypeFont(File ttfFile)
     {
         FontFormat fontFormat = null;
         try
         {
+            TTFParser parser;
             if (ttfFile.getPath().toLowerCase().endsWith(".otf"))
             {
                 fontFormat = FontFormat.OTF;
-                OTFParser parser = new OTFParser(false);
-                OpenTypeFont otf = parser.parse(new RandomAccessReadBufferedFile(ttfFile));
-                addTrueTypeFontImpl(otf, ttfFile);
+                parser = new OTFParser(false);
             }
             else
             {
                 fontFormat = FontFormat.TTF;
-                TTFParser parser = new TTFParser(false);
-                TrueTypeFont ttf = parser.parse(new RandomAccessReadBufferedFile(ttfFile));
-                addTrueTypeFontImpl(ttf, ttfFile);
+                parser = new TTFParser(false);
             }
+            FontHeaders headers = parser.parseTableHeaders(new RandomAccessReadBufferedFile(ttfFile));
+            addTrueTypeFontImpl(headers, ttfFile,
+                    SKIP_CHECKSUMS ? CHECKSUM_PLACEHOLDER : computeHash(Files.newInputStream(ttfFile.toPath())));
         }
         catch (IOException e)
         {
@@ -702,25 +719,27 @@ final class FileSystemFontProvider extends FontProvider
     /**
      * Adds an OTF or TTF font to the file cache. To reduce memory, the parsed font is not cached.
      */
-    private void addTrueTypeFontImpl(TrueTypeFont ttf, File file) throws IOException
+    private void addTrueTypeFontImpl(FontHeaders ttf, File file, String fileHash)
     {
-        try
+        final String error = ttf.getError();
+        if (error == null)
         {
             // read PostScript name, if any
-            if (ttf.getName() != null && ttf.getName().contains("|"))
+            final String name = ttf.getName();
+            if (name != null && name.contains("|"))
             {
                 fontInfoList.add(createFSIgnored(file, FontFormat.TTF, "*skippipeinname*"));
-                LOG.warn("Skipping font with '|' in name " + ttf.getName() + " in file " + file);
+                LOG.warn("Skipping font with '|' in name " + name + " in file " + file);
             }
-            else if (ttf.getName() != null)
+            else if (name != null)
             {
                 // ignore bitmap fonts
-                if (ttf.getHeader() == null)
+                Integer macStyle = ttf.getHeaderMacStyle();
+                if (macStyle == null)
                 {
-                    fontInfoList.add(createFSIgnored(file, FontFormat.TTF, ttf.getName()));
+                    fontInfoList.add(createFSIgnored(file, FontFormat.TTF, name));
                     return;
                 }
-                int macStyle = ttf.getHeader().getMacStyle();
 
                 int sFamilyClass = -1;
                 int usWeightClass = -1;
@@ -738,36 +757,24 @@ final class FileSystemFontProvider extends FontProvider
                     panose = os2WindowsMetricsTable.getPanose();
                 }
 
-                String hash = computeHash(ttf.getOriginalData());
-                String format;
-                if (ttf instanceof OpenTypeFont && ((OpenTypeFont) ttf).isPostScript())
+                FontFormat format;
+                CIDSystemInfo ros = null;
+                if (ttf.isOpenTypePostScript())
                 {
-                    format = "OTF";
-                    CIDSystemInfo ros = null;
-                    OpenTypeFont otf = (OpenTypeFont) ttf;
-                    if (otf.isSupportedOTF() && otf.getCFF() != null)
+                    format = FontFormat.OTF;
+                    String registry = ttf.getOtfRegistry();
+                    String ordering = ttf.getOtfOrdering();
+                    if (registry != null || ordering != null)
                     {
-                        CFFFont cff = otf.getCFF().getFont();
-                        if (cff instanceof CFFCIDFont)
-                        {
-                            CFFCIDFont cidFont = (CFFCIDFont) cff;
-                            String registry = cidFont.getRegistry();
-                            String ordering = cidFont.getOrdering();
-                            int supplement = cidFont.getSupplement();
-                            ros = new CIDSystemInfo(registry, ordering, supplement);
-                        }
+                        ros = new CIDSystemInfo(registry, ordering, ttf.getOtfSupplement());
                     }
-                    fontInfoList.add(new FSFontInfo(file, FontFormat.OTF, ttf.getName(), ros,
-                            usWeightClass, sFamilyClass, ulCodePageRange1, ulCodePageRange2,
-                            macStyle, panose, this, hash, file.lastModified()));
                 }
                 else
                 {
-                    CIDSystemInfo ros = null;
-                    if (ttf.getTableMap().containsKey("gcid"))
+                    byte[] bytes = ttf.getNonOtfTableGCID142();
+                    if (bytes != null)
                     {
                         // Apple's AAT fonts have a "gcid" table with CID info
-                        byte[] bytes = ttf.getTableBytes(ttf.getTableMap().get("gcid"));
                         String reg = new String(bytes, 10, 64, StandardCharsets.US_ASCII);
                         String registryName = reg.substring(0, reg.indexOf('\0'));
                         String ord = new String(bytes, 76, 64, StandardCharsets.US_ASCII);
@@ -775,22 +782,17 @@ final class FileSystemFontProvider extends FontProvider
                         int supplementVersion = bytes[140] << 8 & (bytes[141] & 0xFF);
                         ros = new CIDSystemInfo(registryName, orderName, supplementVersion);
                     }
-                    
-                    format = "TTF";
-                    fontInfoList.add(new FSFontInfo(file, FontFormat.TTF, ttf.getName(), ros,
-                            usWeightClass, sFamilyClass, ulCodePageRange1, ulCodePageRange2,
-                            macStyle, panose, this, hash, file.lastModified()));
+                    format = FontFormat.TTF;
                 }
+                fontInfoList.add(new FSFontInfo(file, format, name, ros,
+                        usWeightClass, sFamilyClass, ulCodePageRange1, ulCodePageRange2,
+                        macStyle, panose, this, fileHash, file.lastModified()));
 
                 if (LOG.isTraceEnabled())
                 {
-                    NamingTable name = ttf.getNaming();
-                    if (name != null)
-                    {
-                        LOG.trace(format +": '" + name.getPostScriptName() + "' / '" +
-                                  name.getFontFamily() + "' / '" +
-                                  name.getFontSubFamily() + "'");
-                    }
+                    LOG.trace(format.name() +": '" + name + "' / '" +
+                              ttf.getFontFamily() + "' / '" +
+                              ttf.getFontSubFamily() + "'");
                 }
             }
             else
@@ -799,21 +801,17 @@ final class FileSystemFontProvider extends FontProvider
                 LOG.warn("Missing 'name' entry for PostScript name in font " + file);
             }
         }
-        catch (IOException e)
+        else
         {
             fontInfoList.add(createFSIgnored(file, FontFormat.TTF, "*skipexception*"));
-            LOG.warn("Could not load font file: " + file, e);
-        }
-        finally
-        {
-            ttf.close();
+            LOG.warn("Could not load font file: " + file + ": " + error);
         }
     }
 
     /**
      * Adds a Type 1 font to the file cache. To reduce memory, the parsed font is not cached.
      */
-    private void addType1Font(File pfbFile) throws IOException
+    private void addType1Font(File pfbFile)
     {
         try (InputStream input = new FileInputStream(pfbFile))
         {
@@ -830,7 +828,7 @@ final class FileSystemFontProvider extends FontProvider
                 LOG.warn("Skipping font with '|' in name " + type1.getName() + " in file " + pfbFile);
                 return;
             }
-            String hash = computeHash(Files.newInputStream(pfbFile.toPath()));
+            String hash = SKIP_CHECKSUMS ? CHECKSUM_PLACEHOLDER : computeHash(Files.newInputStream(pfbFile.toPath()));
             fontInfoList.add(new FSFontInfo(pfbFile, FontFormat.PFB, type1.getName(),
                                             null, -1, -1, 0, 0, -1, null, this, hash, pfbFile.lastModified()));
 


### PR DESCRIPTION
On one machine with 792 fonts (~800MB) scanning takes around 5.5s, after these changes time is down to 0.7s (without checksumming), or 2.2s (with checksums).

In this PR, TTF parsers have an "only headers" mode where each table reads as little information as possible:

* in this mode, whole file is not read to `byte[]`, parser uses `RandomAccessRead` directly, because most of the file is skipped
* only read 5 tables needed for `FSFontInfo` (`name`, `head`, `OS/2`, `CFF `, `gcid`)
* table parsers finish as soon as they have all needed data
* skip checksumming because it is now faster to simply re-parse the file (gated with `pdfbox.fontcache.skipchecksums` system property, for backward compatibility): checksumming 800MB takes 1.5s and parsing headers takes only 0.7s

Additional fixes:
* fixed a memory leak: `RandomAccessRead` passed to `TrueTypeCollection` constructor was never freed.
* ~`NamingTable`: use sorted list instead of multilevel `HashMap`, delay-load Strings (for non-"only headers" mode)~
* ~`TTFSubsetter`: avoid bytes->string->bytes conversion~
* ~streamline I/O: replace readByte() with read(array)~
* ~consolidate `read(buf, offset, len)` loops into `readNBytes()` (allows underflow) and `readExact()` (throwing)~

Breaking changes:
* if `pdfbox.fontcache.skipchecksums` property is set, `.pdfbox.cache` file has dashes instead of checksums
* `.pdfbox.cache` file differs for corrupted fonts (like `LastResort.otf` that throws `IOException: Invalid character code 0xD800`): 
    * original cache lists it as `*skipexception*|OTF||0|0|0|0|0||/System/Library/Fonts/LastResort.otf|6c14c91|1715065304000`
    * after this change it's listed as `LastResort|OTF||||0|0|0||/System/Library/Fonts/LastResort.otf|6c14c91|1715065304000` because we simply do not parse it as extensively to recognize that it's corrupted
* ~`NameRecord.getString()` is now package-private and lazy, renamed to `getStringLazy()`~
* ~new abstract method `TTFDataStream.createSubView()`~ (used a default implementation instead)

Only tested with 3.0 branch, all tests pass, resulting file is the same (except for checksums field, of course, and some `*skipexception*`s).

Should I break it into smaller commits?