### PR TITLE
PDFBOX-5823: remove regexp matcher to reduce memory utilisation

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDAbstractContentStream.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDAbstractContentStream.java
@@ -1621,7 +1621,8 @@ abstract class PDAbstractContentStream implements Closeable
 
         for (String word : words)
         {
-            if (StringUtil.PATTERN_SPACE.matcher(word).matches())
+            if (word == null) continue;
+            if (word.length() == 1 && word.isBlank())
             {
                 out.write(font.encode(word));
             }


### PR DESCRIPTION
PDAbstractContentStream uses StringUtil.PATTERN_SPACE regexp to evaluate if a word has a space in it (https://github.com/apache/pdfbox/blob/trunk/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDAbstractContentStream.java#L1624)

For large documents ~800 pages and small string sequences (like a regular word), it causes a memory overhead (see attached), due to the several extra allocations. I've replaced the regexp for space and \t using word.contains, and since it's a O ( 1 ) operation that does not require extra allocations, memory used has been reduced.

https://issues.apache.org/jira/browse/PDFBOX-5823