### PR TITLE
PDFBOX-5824: allow map threshold to be set as system property

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/cos/COSDictionary.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/cos/COSDictionary.java
@@ -50,13 +50,14 @@ public class COSDictionary extends COSBase implements COSUpdateInfo
      */
     private static final Logger LOG = LogManager.getLogger(COSDictionary.class);
 
+    private static final String SYSPROP_SMALLMAP_THRESHOLD = "org.apache.pdfbox.cosdictionary.smallmap.threshold";
     private static final String PATH_SEPARATOR = "/";
     private static final int MAP_THRESHOLD = 1000;
 
     /**
      * The name-value pairs of this dictionary. The pairs are kept in the order they were added to the dictionary.
      */
-    protected Map<COSName, COSBase> items = new SmallMap<>();
+    protected Map<COSName, COSBase> items;
     private final COSUpdateState updateState;
 
     /**
@@ -65,6 +66,7 @@ public class COSDictionary extends COSBase implements COSUpdateInfo
     public COSDictionary()
     {
         updateState = new COSUpdateState(this);
+        items = initMap();
     }
 
     /**
@@ -74,7 +76,7 @@ public class COSDictionary extends COSBase implements COSUpdateInfo
      */
     public COSDictionary(COSDictionary dict)
     {
-        updateState = new COSUpdateState(this);
+        this();
         addAll(dict);
     }
 
@@ -1352,6 +1354,17 @@ public class COSDictionary extends COSBase implements COSUpdateInfo
             LOG.debug("An exception occurred trying - returning error message instead", e);
             return "COSDictionary{" + e.getMessage() + "}";
         }
+    }
+
+    private Map<COSName, COSBase> initMap() throws NumberFormatException
+    {
+        String property = System.getProperty(SYSPROP_SMALLMAP_THRESHOLD);
+        int threshold = property != null ? Integer.parseInt(property) : MAP_THRESHOLD;
+
+        if (threshold < 1)
+            return new LinkedHashMap<>();
+
+        return new SmallMap<>();
     }
 
     private static String getDictionaryString(COSBase base, List<COSBase> objs) throws IOException

--- a/pdfbox/src/test/java/org/apache/pdfbox/cos/COSDictionaryTest.java
+++ b/pdfbox/src/test/java/org/apache/pdfbox/cos/COSDictionaryTest.java
@@ -16,12 +16,25 @@
  */
 package org.apache.pdfbox.cos;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.LinkedHashMap;
+import org.apache.pdfbox.util.SmallMap;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
 
 class COSDictionaryTest
 {
+    private final String property = "org.apache.pdfbox.cosdictionary.smallmap.threshold";
+
+    @AfterEach
+    void tearDown()
+    {
+        System.clearProperty(property);
+    }
+
     @Test
     void testCOSDictionaryNotEqualsCOSStream()
     {
@@ -34,5 +47,18 @@ class COSDictionaryTest
                 "a COSDictionary shall not be equal to a COSStream with the same dictionary entries");
         assertNotEquals(cosStream, cosDictionary,
                 "a COSStream shall not be equal to a COSDictionary with the same dictionary entries");
+    }
+
+    @Test
+    void testCOSDictionarySystemPropertyDefined()
+    {
+        System.setProperty(property, "0");
+        assertInstanceOf(LinkedHashMap.class, new COSDictionary().items);
+
+        System.clearProperty(property);
+        assertInstanceOf(SmallMap.class, new COSDictionary().items);
+
+        System.setProperty(property, "abc");
+        assertThrows(NumberFormatException.class, COSDictionary::new);
     }
 }


### PR DESCRIPTION
[COSDictionary.MAP_THRESHOLD](https://github.com/apache/pdfbox/blob/trunk/pdfbox/src/main/java/org/apache/pdfbox/cos/COSDictionary.java#L54) controls which Map class is used to optimize memory usage. By default, a SmallMap is used. However, if the number of items in a COSDictionary reaches the MAP_THRESHOLD value (hardcoded to 1,000), the references [are copied ](https://github.com/apache/pdfbox/blob/trunk/pdfbox/src/main/java/org/apache/pdfbox/cos/COSDictionary.java#L208)to a LinkedHashMap.

For larger documents, where the COSDictionary is expected to be substantial bigger than this limit, this copying occurs frequently. Additionally, [SmallMap.keySet is not efficient](https://github.com/apache/pdfbox/blob/trunk/pdfbox/src/main/java/org/apache/pdfbox/util/SmallMap.java#L281).

Some properties already supported in this library are:

* pdftextstripper.indent
* pdftextstripper.drop
* org.apache.pdfbox.filter.deflatelevel

https://issues.apache.org/jira/browse/PDFBOX-5824