### PR TITLE
Add method to merge PDF from InputStream source

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/multipdf/PDFMergerUtility.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/multipdf/PDFMergerUtility.java
@@ -16,10 +16,7 @@
  */
 package org.apache.pdfbox.multipdf;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.OutputStream;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -43,6 +40,7 @@ import org.apache.pdfbox.cos.COSObject;
 import org.apache.pdfbox.cos.COSStream;
 import org.apache.pdfbox.io.IOUtils;
 import org.apache.pdfbox.io.RandomAccessRead;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.io.RandomAccessStreamCache.StreamCacheCreateFunction;
 import org.apache.pdfbox.pdfwriter.compress.CompressParameters;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -305,6 +303,18 @@ public class PDFMergerUtility
     public void addSource(File source) throws FileNotFoundException
     {
         sources.add(source);
+    }
+
+    /**
+     * Add a source to the list of documents to merge.
+     *
+     * @param source InputStream representing source document
+     *
+     * @throws IOException If something went wrong while copying the data
+     */
+    public void addSource(InputStream source) throws IOException
+    {
+        sources.add(new RandomAccessReadBuffer(source));
     }
 
     /**


### PR DESCRIPTION
Introduced a new `addSource` method that accepts an `InputStream` as a parameter, enabling merging of PDFs directly from streams keeping the developer from having to understand the RandomAccessRead interfaces and use a common way of accessing file data.

Ideally this is merged with the 3.0 branch as well.