### PR TITLE
Upgrade Log4j and Harden Annotation Processing

### DIFF
--- a/debugger/pom.xml
+++ b/debugger/pom.xml
@@ -99,6 +99,46 @@
     <plugins>
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <!-- Enable generation of Log4j Core plugin metadata -->
+            <executions>
+                <execution>
+                    <id>default-compile</id>
+                    <configuration>
+                        <!--
+                          ~ Enables annotation processing
+                          ~ This option is only recognized by recent JDK versions:
+                          ~ - 11.0.23 or later
+                          ~ - 17.0.11 or later
+                          -->
+                        <proc>full</proc>
+                        <annotationProcessorPaths>
+                            <path>
+                                <groupId>org.apache.logging.log4j</groupId>
+                                <artifactId>log4j-core</artifactId>
+                            </path>
+                        </annotationProcessorPaths>
+                        <annotationProcessors>
+                            <!-- Generate a `Log4j2Plugins.dat` descriptor -->
+                            <annotationProcessor>
+                                org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor
+                            </annotationProcessor>
+                            <!-- Generate GraalVM reachability metadata -->
+                            <annotationProcessor>
+                                org.apache.logging.log4j.core.config.plugins.processor.GraalVmProcessor
+                            </annotationProcessor>
+                        </annotationProcessors>
+                        <compilerArgs>
+                            <!-- Required arguments for GraalVmProcessor -->
+                            <arg>-Alog4j.graalvm.groupId=${project.groupId}</arg>
+                            <arg>-Alog4j.graalvm.artifactId=${project.artifactId}</arg>
+                        </compilerArgs>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
             <configuration>
                 <archive>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -56,7 +56,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <bouncycastle.version>1.81</bouncycastle.version>
-    <log4j2.version>2.24.3</log4j2.version>
+    <log4j2.version>2.25.0</log4j2.version>
     <junit.version>5.13.1</junit.version>
     <jbig2.version>3.0.4</jbig2.version>
     <jai.version>1.4.0</jai.version>
@@ -160,6 +160,8 @@
                 <configuration>
                     <showDeprecation>true</showDeprecation>
                     <encoding>UTF-8</encoding>
+                    <!-- Default to no annotation processing unless explicitly enabled -->
+                    <proc>none</proc>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This PR makes the following changes:

* Upgrades Log4j to version `2.25.0`.
* Hardens annotation processing in response to the [JDK 23 change in default annotation processing policy](https://inside.java/2024/06/18/quality-heads-up/), which deprecates implicit annotation processor discovery. This change has been backported to earlier JDKs as well.

### Key Improvements:

* Annotation processing is now disabled by default (`<proc>none</proc>`) to ensure only explicitly declared processors are run — a best practice that improves build predictability and mitigates supply chain risks ([background](https://javapro.io/2024/11/19/discovering-the-perfect-java-supply-chain-attack-vector-and-how-it-got-fixed/)).

* The `pdfbox-debugger` module is now explicitly compiled using:

  * `PluginProcessor` to generate the `Log4j2Plugins.dat` descriptor.
  * The new `GraalVmProcessor` to generate GraalVM reachability metadata.

* Both processors are declared explicitly along with the required compiler arguments:

  ```text
  -Alog4j.graalvm.groupId=${project.groupId}
  -Alog4j.graalvm.artifactId=${project.artifactId}
  ```

  This avoids build failures introduced by `GraalVmProcessor` when those parameters are missing.

### Why This Matters:

Log4j 2.25.0 introduces stricter behavior for `GraalVmProcessor`, which fails with an error if required options aren't set. Combined with changes to how annotation processors are discovered in JDK 23+, these updates ensure that:

* Build behavior is explicit and secure.
* The `DebugLogAppender` remains compatible with ahead-of-time compilation tools like GraalVM.
* The project is future-proofed against evolving Java defaults and security posture.