### PR TITLE
PDFBOX-6032: add configurable default image factory

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/CustomFactory.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/CustomFactory.java
@@ -5,6 +5,6 @@ import java.io.IOException;
 import org.apache.pdfbox.pdmodel.PDDocument;
 
 @FunctionalInterface
-public interface DefaultFactory {
+public interface CustomFactory {
 	PDImageXObject createFromByteArray(PDDocument document, byte[] byteArray) throws IOException;
 }

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/CustomFactory.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/CustomFactory.java
@@ -4,7 +4,19 @@ import java.io.IOException;
 
 import org.apache.pdfbox.pdmodel.PDDocument;
 
+/**
+ * A functional interface that allows users to define a custom strategy for converting
+ * image data as a byte array into a {@link PDImageXObject}.
+ */
 @FunctionalInterface
 public interface CustomFactory {
+	/**
+	 * Creates a {@link PDImageXObject} from the given image byte array and document context.
+	 *
+	 * @param document the document that shall use this PDImageXObject.
+	 * @param byteArray the image data as a byte array
+	 * @return a PDImageXObject.
+	 * @throws IOException if there is an error when creating the PDImageXObject.
+	 */
 	PDImageXObject createFromByteArray(PDDocument document, byte[] byteArray) throws IOException;
 }

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/DefaultFactory.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/DefaultFactory.java
@@ -1,0 +1,10 @@
+package org.apache.pdfbox.pdmodel.graphics.image;
+
+import java.io.IOException;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+
+@FunctionalInterface
+public interface DefaultFactory {
+	PDImageXObject createFromByteArray(PDDocument document, byte[] byteArray) throws IOException;
+}

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/PDImageXObject.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/PDImageXObject.java
@@ -340,47 +340,7 @@ public final class PDImageXObject extends PDXObject implements PDImage
      */
     public static PDImageXObject createFromByteArray(PDDocument document, byte[] byteArray, String name) throws IOException
     {
-        FileType fileType = FileTypeDetector.detectFileType(byteArray);
-        if (fileType == null)
-        {
-            throw new IllegalArgumentException("Image type not supported: " + name);
-        }
-
-        if (fileType == FileType.JPEG)
-        {
-            return JPEGFactory.createFromByteArray(document, byteArray);
-        }
-        if (fileType == FileType.PNG)
-        {
-            // Try to directly convert the image without recoding it.
-            PDImageXObject image = PNGConverter.convertPNGImage(document, byteArray);
-            if (image != null)
-            {
-                return image;
-            }
-        }
-        if (fileType == FileType.TIFF)
-        {
-            try
-            {
-                return CCITTFactory.createFromByteArray(document, byteArray);
-            }
-            catch (IOException ex)
-            {
-                LOG.debug("Reading as TIFF failed, setting fileType to PNG", ex);
-                // Plan B: try reading with ImageIO
-                // common exception:
-                // First image in tiff is not CCITT T4 or T6 compressed
-                fileType = FileType.PNG;
-            }
-        }
-        if (fileType == FileType.BMP || fileType == FileType.GIF || fileType == FileType.PNG)
-        {
-            ByteArrayInputStream bais = new ByteArrayInputStream(byteArray);
-            BufferedImage bim = ImageIO.read(bais);
-            return LosslessFactory.createFromImage(document, bim);
-        }
-        throw new IllegalArgumentException("Image type " + fileType + " not supported: " + name);
+        return createFromByteArray(document, byteArray, name, null);
     }
 
     /**
@@ -391,7 +351,7 @@ public final class PDImageXObject extends PDXObject implements PDImage
      * @param document the document that shall use this PDImageXObject.
      * @param byteArray bytes from an image file.
      * @param name name of image file for exception messages, can be null.
-     * @param defaultFactory optional factory used to handle BMP, GIF, or fallback cases 
+     * @param customFactory optional factory used to handle BMP, GIF, or fallback cases 
      *                       (e.g., for PNG or TIFF). If {@code null}, this method delegates to
      *                       {@link #createFromByteArray(PDDocument, byte[], String)}.
      * @return a PDImageXObject.
@@ -399,12 +359,8 @@ public final class PDImageXObject extends PDXObject implements PDImage
      * PDImageXObject.
      * @throws IllegalArgumentException if the image type is not supported.
      */
-    public static PDImageXObject createFromByteArray(PDDocument document, byte[] byteArray, String name, DefaultFactory defaultFactory) throws IOException
+    public static PDImageXObject createFromByteArray(PDDocument document, byte[] byteArray, String name, CustomFactory customFactory) throws IOException
     {
-        if (defaultFactory == null) {
-            return createFromByteArray(document, byteArray, name);
-        }
-        
         FileType fileType = FileTypeDetector.detectFileType(byteArray);
         if (fileType == null)
         {
@@ -441,7 +397,14 @@ public final class PDImageXObject extends PDXObject implements PDImage
         }
         if (fileType == FileType.BMP || fileType == FileType.GIF || fileType == FileType.PNG)
         {
-            return defaultFactory.createFromByteArray(document, byteArray);
+            if (customFactory != null)
+            {
+                return customFactory.createFromByteArray(document, byteArray);
+            }
+            
+            ByteArrayInputStream bais = new ByteArrayInputStream(byteArray);
+            BufferedImage bim = ImageIO.read(bais);
+            return LosslessFactory.createFromImage(document, bim);
         }
         throw new IllegalArgumentException("Image type " + fileType + " not supported: " + name);
     }

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/PDImageXObject.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/PDImageXObject.java
@@ -384,6 +384,69 @@ public final class PDImageXObject extends PDXObject implements PDImage
     }
 
     /**
+     * Create a PDImageXObject from an image byte array. This overloaded version allows providing 
+     * a custom factory to handle specific image formats, such as BMP and GIF, or to act as a 
+     * fallback strategy when the default converters (e.g., for PNG or TIFF) fail.
+     *
+     * @param document the document that shall use this PDImageXObject.
+     * @param byteArray bytes from an image file.
+     * @param name name of image file for exception messages, can be null.
+     * @param defaultFactory optional factory used to handle BMP, GIF, or fallback cases 
+     *                       (e.g., for PNG or TIFF). If {@code null}, this method delegates to
+     *                       {@link #createFromByteArray(PDDocument, byte[], String)}.
+     * @return a PDImageXObject.
+     * @throws IOException if there is an error when reading the file or creating the
+     * PDImageXObject.
+     * @throws IllegalArgumentException if the image type is not supported.
+     */
+    public static PDImageXObject createFromByteArray(PDDocument document, byte[] byteArray, String name, DefaultFactory defaultFactory) throws IOException
+    {
+        if (defaultFactory == null) {
+            return createFromByteArray(document, byteArray, name);
+        }
+        
+        FileType fileType = FileTypeDetector.detectFileType(byteArray);
+        if (fileType == null)
+        {
+            throw new IllegalArgumentException("Image type not supported: " + name);
+        }
+
+        if (fileType == FileType.JPEG)
+        {
+            return JPEGFactory.createFromByteArray(document, byteArray);
+        }
+        if (fileType == FileType.PNG)
+        {
+            // Try to directly convert the image without recoding it.
+            PDImageXObject image = PNGConverter.convertPNGImage(document, byteArray);
+            if (image != null)
+            {
+                return image;
+            }
+        }
+        if (fileType == FileType.TIFF)
+        {
+            try
+            {
+                return CCITTFactory.createFromByteArray(document, byteArray);
+            }
+            catch (IOException ex)
+            {
+                LOG.debug("Reading as TIFF failed, setting fileType to PNG", ex);
+                // Plan B: try reading with ImageIO
+                // common exception:
+                // First image in tiff is not CCITT T4 or T6 compressed
+                fileType = FileType.PNG;
+            }
+        }
+        if (fileType == FileType.BMP || fileType == FileType.GIF || fileType == FileType.PNG)
+        {
+            return defaultFactory.createFromByteArray(document, byteArray);
+        }
+        throw new IllegalArgumentException("Image type " + fileType + " not supported: " + name);
+    }
+
+    /**
      * Returns the metadata associated with this XObject, or null if there is none.
      * @return the metadata associated with this object.
      */

--- a/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/graphics/image/PDImageXObjectTest.java
+++ b/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/graphics/image/PDImageXObjectTest.java
@@ -130,29 +130,16 @@ class PDImageXObjectTest
     }
 
     /**
-     * Test of createFromByteArray method with DefaultFactory parameter, of class PDImageXObject.
+     * Test of createFromByteArray method with CustomFactory parameter, of class PDImageXObject.
      * @throws java.io.IOException
      * @throws java.net.URISyntaxException
      */
     @Test
-    void testCreateFromByteArrayWithDefaultFactory() throws IOException, URISyntaxException
+    void testCreateFromByteArrayWithCustomFactory() throws IOException, URISyntaxException
     {
-        testCompareCreatedFromByteArrayWithCreatedByDefaultFactory("gif.gif");
-        testCompareCreatedFromByteArrayWithCreatedByDefaultFactory("gif-1bit-transparent.gif");
-        testCompareCreatedFromByteArrayWithCreatedByDefaultFactory("lzw.tif");
-    }
-
-    /**
-     * Test of createFromByteArray method with null DefaultFactory parameter, of class PDImageXObject.
-     * @throws java.io.IOException
-     * @throws java.net.URISyntaxException
-     */
-    @Test
-    void testCreateFromByteArrayWithNullDefaultFactory() throws IOException, URISyntaxException
-    {
-        testCompareCreatedFromByteArrayWithCreatedByNullDefaultFactory("gif.gif");
-        testCompareCreatedFromByteArrayWithCreatedByNullDefaultFactory("gif-1bit-transparent.gif");
-        testCompareCreatedFromByteArrayWithCreatedByNullDefaultFactory("lzw.tif");
+        testCompareCreatedFromByteArrayWithCreatedByCustomFactory("gif.gif");
+        testCompareCreatedFromByteArrayWithCreatedByCustomFactory("gif-1bit-transparent.gif");
+        testCompareCreatedFromByteArrayWithCreatedByCustomFactory("lzw.tif");
     }
 
     private void testCompareCreatedFileByExtensionWithCreatedByLosslessFactory(String filename)
@@ -348,7 +335,7 @@ class PDImageXObjectTest
         }
     }
 
-    private void testCompareCreatedFromByteArrayWithCreatedByDefaultFactory(String filename)
+    private void testCompareCreatedFromByteArrayWithCreatedByCustomFactory(String filename)
             throws IOException, URISyntaxException
     {
         try (PDDocument doc = new PDDocument())
@@ -357,34 +344,12 @@ class PDImageXObjectTest
             InputStream in = new FileInputStream(file);
             byte[] byteArray = in.readAllBytes();
             
-            DefaultFactory defaultFactory = this::alphaFlattenedJPEGFactory;
+            CustomFactory customFactory = this::alphaFlattenedJPEGFactory;
             
-            PDImageXObject image = PDImageXObject.createFromByteArray(doc, byteArray, filename, defaultFactory);
+            PDImageXObject image = PDImageXObject.createFromByteArray(doc, byteArray, filename, customFactory);
             
             PDImageXObject expectedImage = alphaFlattenedJPEGFactory(doc, byteArray);
             
-            assertEquals(expectedImage.getSuffix(), image.getSuffix());
-            checkIdentARGB(image.getImage(), expectedImage.getImage());
-        }
-    }
-
-    private void testCompareCreatedFromByteArrayWithCreatedByNullDefaultFactory(String filename)
-        throws IOException, URISyntaxException
-    {
-        try (PDDocument doc = new PDDocument())
-        {
-            File file = new File(PDImageXObjectTest.class.getResource(filename).toURI());
-            InputStream in = new FileInputStream(file);
-            byte[] byteArray = in.readAllBytes();
-
-            DefaultFactory defaultFactory = null;
-
-            PDImageXObject image = PDImageXObject.createFromByteArray(doc, byteArray, filename, defaultFactory);
-
-            ByteArrayInputStream bais = new ByteArrayInputStream(byteArray);
-            BufferedImage bim = ImageIO.read(bais);
-            PDImageXObject expectedImage = LosslessFactory.createFromImage(doc, bim);
-
             assertEquals(expectedImage.getSuffix(), image.getSuffix());
             checkIdentARGB(image.getImage(), expectedImage.getImage());
         }

--- a/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/graphics/image/PDImageXObjectTest.java
+++ b/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/graphics/image/PDImageXObjectTest.java
@@ -19,7 +19,11 @@ package org.apache.pdfbox.pdmodel.graphics.image;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.awt.*;
 import java.awt.image.BufferedImage;
+import java.awt.image.ColorModel;
+import java.awt.image.WritableRaster;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -123,6 +127,32 @@ class PDImageXObjectTest
         testCompareCreatedFromByteArrayWithCreatedByLosslessFactory("png_indexed_8bit_alpha.png");
         testCompareCreatedFromByteArrayWithCreatedByLosslessFactory("png.png");
         testCompareCreatedFromByteArrayWithCreatedByLosslessFactory("lzw.tif");
+    }
+
+    /**
+     * Test of createFromByteArray method with DefaultFactory parameter, of class PDImageXObject.
+     * @throws java.io.IOException
+     * @throws java.net.URISyntaxException
+     */
+    @Test
+    void testCreateFromByteArrayWithDefaultFactory() throws IOException, URISyntaxException
+    {
+        testCompareCreatedFromByteArrayWithCreatedByDefaultFactory("gif.gif");
+        testCompareCreatedFromByteArrayWithCreatedByDefaultFactory("gif-1bit-transparent.gif");
+        testCompareCreatedFromByteArrayWithCreatedByDefaultFactory("lzw.tif");
+    }
+
+    /**
+     * Test of createFromByteArray method with null DefaultFactory parameter, of class PDImageXObject.
+     * @throws java.io.IOException
+     * @throws java.net.URISyntaxException
+     */
+    @Test
+    void testCreateFromByteArrayWithNullDefaultFactory() throws IOException, URISyntaxException
+    {
+        testCompareCreatedFromByteArrayWithCreatedByNullDefaultFactory("gif.gif");
+        testCompareCreatedFromByteArrayWithCreatedByNullDefaultFactory("gif-1bit-transparent.gif");
+        testCompareCreatedFromByteArrayWithCreatedByNullDefaultFactory("lzw.tif");
     }
 
     private void testCompareCreatedFileByExtensionWithCreatedByLosslessFactory(String filename)
@@ -318,6 +348,48 @@ class PDImageXObjectTest
         }
     }
 
+    private void testCompareCreatedFromByteArrayWithCreatedByDefaultFactory(String filename)
+            throws IOException, URISyntaxException
+    {
+        try (PDDocument doc = new PDDocument())
+        {
+            File file = new File(PDImageXObjectTest.class.getResource(filename).toURI());
+            InputStream in = new FileInputStream(file);
+            byte[] byteArray = in.readAllBytes();
+            
+            DefaultFactory defaultFactory = this::alphaFlattenedJPEGFactory;
+            
+            PDImageXObject image = PDImageXObject.createFromByteArray(doc, byteArray, filename, defaultFactory);
+            
+            PDImageXObject expectedImage = alphaFlattenedJPEGFactory(doc, byteArray);
+            
+            assertEquals(expectedImage.getSuffix(), image.getSuffix());
+            checkIdentARGB(image.getImage(), expectedImage.getImage());
+        }
+    }
+
+    private void testCompareCreatedFromByteArrayWithCreatedByNullDefaultFactory(String filename)
+        throws IOException, URISyntaxException
+    {
+        try (PDDocument doc = new PDDocument())
+        {
+            File file = new File(PDImageXObjectTest.class.getResource(filename).toURI());
+            InputStream in = new FileInputStream(file);
+            byte[] byteArray = in.readAllBytes();
+
+            DefaultFactory defaultFactory = null;
+
+            PDImageXObject image = PDImageXObject.createFromByteArray(doc, byteArray, filename, defaultFactory);
+
+            ByteArrayInputStream bais = new ByteArrayInputStream(byteArray);
+            BufferedImage bim = ImageIO.read(bais);
+            PDImageXObject expectedImage = LosslessFactory.createFromImage(doc, bim);
+
+            assertEquals(expectedImage.getSuffix(), image.getSuffix());
+            checkIdentARGB(image.getImage(), expectedImage.getImage());
+        }
+    }
+
     private void checkIdentARGB(BufferedImage expectedImage, BufferedImage actualImage)
     {
         String errMsg = "";
@@ -337,5 +409,31 @@ class PDImageXObjectTest
                 assertEquals(expectedImage.getRGB(x, y), actualImage.getRGB(x, y), errMsg);
             }
         }
-    }    
+    }
+
+    private PDImageXObject alphaFlattenedJPEGFactory(PDDocument document, byte[] byteArray) throws IOException {
+        ByteArrayInputStream bais = new ByteArrayInputStream(byteArray);
+        BufferedImage bim = ImageIO.read(bais);
+
+        if (bim.isAlphaPremultiplied()) {
+            ColorModel colorModel = bim.getColorModel();
+            WritableRaster raster = bim.copyData(null);
+            bim = new BufferedImage(colorModel, raster, false, null);
+        }
+
+        BufferedImage flattened = new BufferedImage(
+            bim.getWidth(),
+            bim.getHeight(),
+            BufferedImage.TYPE_INT_RGB
+        );
+
+        Graphics2D g = flattened.createGraphics();
+        g.setComposite(AlphaComposite.SrcOver);
+        g.setColor(Color.WHITE);
+        g.fillRect(0, 0, flattened.getWidth(), flattened.getHeight());
+        g.drawImage(bim, 0, 0, null);
+        g.dispose();
+
+        return JPEGFactory.createFromImage(document, flattened);
+    }
 }


### PR DESCRIPTION
- This PR addresses [PDFBOX-6032](https://issues.apache.org/jira/browse/PDFBOX-6032) by introducing a new overload of PDImageXObject#createFromByteArray that accepts a user-supplied defaultFactory parameter for customizable image conversion behavior.
- The goal is to allow users to provide a defaultFactory for custom image conversion. This factory is used directly for formats like BMP and GIF, and acts as a fallback for PNG and TIFF when the optimized conversion path fails and would otherwise fall back to LosslessFactory.