### PR TITLE
PDFBOX-6061: Prevent NullPointerException in COSDictionary.

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/cos/COSDictionary.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/cos/COSDictionary.java
@@ -105,8 +105,8 @@ public class COSDictionary extends COSBase implements COSUpdateInfo
         {
             Object nextValue = entry.getValue();
             if (nextValue.equals(value)
-                    || (nextValue instanceof COSObject && ((COSObject) nextValue).getObject()
-                            .equals(value)))
+                    || (nextValue instanceof COSObject && !((COSObject) nextValue).isObjectNull() &&
+                            ((COSObject) nextValue).getObject().equals(value)))
             {
                 return entry.getKey();
             }


### PR DESCRIPTION
When iterating the items in a COSDictionary to retrieve one particular item in getKeyForValue(), we add a null check to prevent a call to getObject on a null COSObject.