### PR TITLE
improve write operations for RC4Cipher

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/encryption/RC4Cipher.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/encryption/RC4Cipher.java
@@ -95,6 +95,14 @@ class RC4Cipher
         data[ secondIndex ] = tmp;
     }
 
+    private int encrypt(byte aByte) {
+        b = (b + 1) % 256;
+        c = (salt[b] + c) % 256;
+        swap( salt, b, c );
+        int saltIndex = (salt[b] + salt[c]) % 256;
+        return aByte ^ (byte)salt[saltIndex];
+    }
+
     /**
      * This will encrypt and write the next byte.
      *
@@ -105,11 +113,7 @@ class RC4Cipher
      */
     public void write( byte aByte, OutputStream output ) throws IOException
     {
-        b = (b + 1) % 256;
-        c = (salt[b] + c) % 256;
-        swap( salt, b, c );
-        int saltIndex = (salt[b] + salt[c]) % 256;
-        output.write(aByte ^ (byte)salt[saltIndex]);
+        output.write(encrypt(aByte));
     }
 
     /**
@@ -122,10 +126,7 @@ class RC4Cipher
      */
     public void write( byte[] data, OutputStream output ) throws IOException
     {
-        for (byte aData : data)
-        {
-            write(aData, output);
-        }
+        write(data, 0, data.length, output);
     }
 
     /**
@@ -142,7 +143,7 @@ class RC4Cipher
         int amountRead;
         while( (amountRead = data.read( buffer )) != -1 )
         {
-            write( buffer, 0, amountRead, output );
+            write( buffer, 0, amountRead, output, buffer);
         }
     }
 
@@ -158,9 +159,16 @@ class RC4Cipher
      */
     public void write( byte[] data, int offset, int len, OutputStream output) throws IOException
     {
-        for( int i = offset; i < offset + len; i++ )
+        write(data, offset, len, output, new byte[len]);
+    }
+
+    private void write(byte[] data, int offset, int len, OutputStream output, byte[] buffer) throws IOException
+    {
+        for (int i = 0, j = offset; i < len; ++i, ++j)
         {
-            write( data[i], output );
+            buffer[i] = (byte)encrypt(data[j]);
         }
+
+        output.write(buffer, 0, len);
     }
 }


### PR DESCRIPTION
The idea is to reduce the time of write operations by writing an array into the output stream rather than individual bytes where possible. This approach has pos and cons. The pos: reducing operations time. The cons: this array should not be very big or we will get an OutOfMemoryException. According the tests, the maximum length of that array is 1024. If you think so, I can rewrite the write(byte[], int, int, OutputStream) method by setting a maximum lenght of the array (buffer, a line 146). It will be something like in the method write( InputStream, OutputStream).