### PR TITLE
Add option to implement custom `ICOSVisitor` behaviour for `COSObject`

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/cos/COSObject.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/cos/COSObject.java
@@ -160,15 +160,7 @@ public class COSObject extends COSBase implements COSUpdateInfo
     @Override
     public void accept( ICOSVisitor visitor ) throws IOException
     {
-        COSBase object = getObject();
-        if (object != null)
-        {
-            object.accept(visitor);
-        }
-        else
-        {
-            COSNull.NULL.accept(visitor);
-        }
+        visitor.visitFromObject(this);
     }
 
     /**

--- a/pdfbox/src/main/java/org/apache/pdfbox/cos/ICOSVisitor.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/cos/ICOSVisitor.java
@@ -104,4 +104,21 @@ public interface ICOSVisitor
      * @throws IOException If there is an error while visiting this object.
      */
     void visitFromString(COSString obj) throws IOException;
+
+    /**
+     * Notification of visit to object.
+     * @param obj The Object that is being visited.
+     * @throws IOException If there is an error while visiting this object.
+     */
+    default void visitFromObject(COSObject obj) throws IOException
+    {
+        COSBase base = obj.getObject();
+        if (base == null)
+        {
+            visitFromNull(COSNull.NULL);
+        } else
+        {
+            base.accept(this);
+        }
+    }
 }


### PR DESCRIPTION
`COSObject` overrides the `COSBase#accept` method to visit its inner object. 

However, this approach limits the ability of an `ICOSVisitor` superclass to define a custom behaviour when a `COSObject` is visited. 

This patch adds the method `ICOSVisitor#visitFromObject` to provide for flexibility for such cases.