### PR TITLE
fix memory leak for RandomAccessReadBuffer(InputStream)

### DIFF
--- a/io/src/main/java/org/apache/pdfbox/io/RandomAccessReadBuffer.java
+++ b/io/src/main/java/org/apache/pdfbox/io/RandomAccessReadBuffer.java
@@ -110,19 +110,19 @@ public class RandomAccessReadBuffer implements RandomAccessRead
         int remainingBytes = chunkSize;
         int offset = 0;
         byte[] eofCheck = new byte[1];
-        while (remainingBytes > 0 &&
-                (bytesRead = input.read(currentBuffer.array(), offset, remainingBytes)) > -1)
-        {
-            remainingBytes -= bytesRead;
-            offset += bytesRead;
-            size += bytesRead;
-            if (remainingBytes == 0 && input.read(eofCheck) > 0)
-            {
-                expandBuffer();
-                currentBuffer.put(eofCheck);
-                offset = 1;
-                remainingBytes = chunkSize - 1;
-                size++;
+        try (input) {
+            while (remainingBytes > 0 &&
+                    (bytesRead = input.read(currentBuffer.array(), offset, remainingBytes)) > -1) {
+                remainingBytes -= bytesRead;
+                offset += bytesRead;
+                size += bytesRead;
+                if (remainingBytes == 0 && input.read(eofCheck) > 0) {
+                    expandBuffer();
+                    currentBuffer.put(eofCheck);
+                    offset = 1;
+                    remainingBytes = chunkSize - 1;
+                    size++;
+                }
             }
         }
         currentBuffer.limit(offset);


### PR DESCRIPTION
1 I think we should close this stream especially if we got it by this way (CMapParser.getExternalCMap):

InputStream is = getClass().getResourceAsStream(name);

2 Possible optimisation for future:
We often use ByteArrayInputStream as parameter of the constructor RandomAccessReadBuffer(InputStream). The ByteArrayInputStream is the array wrapper. There is no need to create List<ByteBuffer> for this case.