### PR TITLE
extract a couple variables in PDLab.getDefaultRangeArray method

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/color/PDLab.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/color/PDLab.java
@@ -183,11 +183,14 @@ public final class PDLab extends PDCIEDictionaryBasedColorSpace
      */
     private COSArray getDefaultRangeArray()
     {
+        COSFloat minus100 = new COSFloat(-100f);
+        COSFloat plus100 = new COSFloat(100f);
         COSArray range = new COSArray();
-        range.add(new COSFloat(-100));
-        range.add(new COSFloat(100));
-        range.add(new COSFloat(-100));
-        range.add(new COSFloat(100));
+        range.add(minus100);
+        range.add(plus100);
+        range.add(minus100);
+        range.add(plus100);
+        System.out.println("getDefaultRangeArray");
         return range;
     }
 


### PR DESCRIPTION
Two more solutions: the minus100 and plus100 variables can be extracted as fields or static fields of this class because they used in several methods and COSFloat is immutable.