### PR TITLE
close PDFStreamParser

### DIFF
--- a/examples/src/main/java/org/apache/pdfbox/examples/util/RemoveAllText.java
+++ b/examples/src/main/java/org/apache/pdfbox/examples/util/RemoveAllText.java
@@ -126,38 +126,49 @@ public final class RemoveAllText
 
     private static List<Object> createTokensWithoutText(PDContentStream contentStream) throws IOException
     {
-        PDFStreamParser parser = new PDFStreamParser(contentStream);
-        Object token = parser.parseNextToken();
         List<Object> newTokens = new ArrayList<>();
-        while (token != null)
+        PDFStreamParser parser = null;
+        try
         {
-            if (token instanceof Operator)
+            parser = new PDFStreamParser(contentStream);
+            Object token = parser.parseNextToken();
+            while (token != null)
             {
-                Operator op = (Operator) token;
-                String opName = op.getName();
-                if (OperatorName.SHOW_TEXT_ADJUSTED.equals(opName)
-                        || OperatorName.SHOW_TEXT.equals(opName)
-                        || OperatorName.SHOW_TEXT_LINE.equals(opName))
+                if (token instanceof Operator)
                 {
-                    // remove the argument to this operator
-                    newTokens.remove(newTokens.size() - 1);
+                    Operator op = (Operator) token;
+                    String opName = op.getName();
+                    if (OperatorName.SHOW_TEXT_ADJUSTED.equals(opName)
+                            || OperatorName.SHOW_TEXT.equals(opName)
+                            || OperatorName.SHOW_TEXT_LINE.equals(opName))
+                    {
+                        // remove the argument to this operator
+                        newTokens.remove(newTokens.size() - 1);
 
-                    token = parser.parseNextToken();
-                    continue;
-                }
-                else if (OperatorName.SHOW_TEXT_LINE_AND_SPACE.equals(opName))
-                {
-                    // remove the 3 arguments to this operator
-                    newTokens.remove(newTokens.size() - 1);
-                    newTokens.remove(newTokens.size() - 1);
-                    newTokens.remove(newTokens.size() - 1);
+                        token = parser.parseNextToken();
+                        continue;
+                    }
+                    else if (OperatorName.SHOW_TEXT_LINE_AND_SPACE.equals(opName))
+                    {
+                        // remove the 3 arguments to this operator
+                        newTokens.remove(newTokens.size() - 1);
+                        newTokens.remove(newTokens.size() - 1);
+                        newTokens.remove(newTokens.size() - 1);
 
-                    token = parser.parseNextToken();
-                    continue;
+                        token = parser.parseNextToken();
+                        continue;
+                    }
                 }
+                newTokens.add(token);
+                token = parser.parseNextToken();
             }
-            newTokens.add(token);
-            token = parser.parseNextToken();
+        }
+        finally
+        {
+            if (parser != null)
+            {
+                parser.close();
+            }
         }
         return newTokens;
     }

--- a/pdfbox/src/main/java/org/apache/pdfbox/contentstream/PDFStreamEngine.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/contentstream/PDFStreamEngine.java
@@ -533,19 +533,22 @@ public abstract class PDFStreamEngine
     private void processStreamOperators(PDContentStream contentStream) throws IOException
     {
         List<COSBase> arguments = new ArrayList<>();
-        PDFStreamParser parser = new PDFStreamParser(contentStream);
-        Object token = parser.parseNextToken();
-
-        boolean isFirstOperator = true;
+        PDFStreamParser parser = null;
         boolean oldShouldProcessColorOperators = shouldProcessColorOperators;
-        shouldProcessColorOperators = true;
-        if (contentStream instanceof PDTilingPattern &&
-            ((PDTilingPattern) contentStream).getPaintType() == PDTilingPattern.PAINT_UNCOLORED)
-        {
-            shouldProcessColorOperators = false;
-        }
+
         try
         {
+            parser = new PDFStreamParser(contentStream);
+            Object token = parser.parseNextToken();
+
+            boolean isFirstOperator = true;
+            shouldProcessColorOperators = true;
+            if (contentStream instanceof PDTilingPattern &&
+                ((PDTilingPattern) contentStream).getPaintType() == PDTilingPattern.PAINT_UNCOLORED)
+            {
+                shouldProcessColorOperators = false;
+            }
+
             while (token != null)
             {
                 if (token instanceof Operator)
@@ -568,6 +571,10 @@ public abstract class PDFStreamEngine
         }
         finally
         {
+            if (parser != null)
+            {
+                parser.close();
+            }
             shouldProcessColorOperators = oldShouldProcessColorOperators;
         }
     }

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/PDType3CharProc.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/PDType3CharProc.java
@@ -113,41 +113,52 @@ public final class PDType3CharProc implements COSObjectable, PDContentStream
     public PDRectangle getGlyphBBox() throws IOException
     {
         List<COSBase> arguments = new ArrayList<>();
-        PDFStreamParser parser = new PDFStreamParser(this);
-        Object token = parser.parseNextToken();
-        while (token != null)
+        PDFStreamParser parser = null;
+        try
         {
-            if (token instanceof Operator)
+            parser = new PDFStreamParser(this);
+            Object token = parser.parseNextToken();
+            while (token != null)
             {
-                if (((Operator) token).getName().equals("d1") && arguments.size() == 6)
+                if (token instanceof Operator)
                 {
-                    for (int i = 0; i < 6; ++i)
+                    if (((Operator) token).getName().equals("d1") && arguments.size() == 6)
                     {
-                        if (!(arguments.get(i) instanceof COSNumber))
+                        for (int i = 0; i < 6; ++i)
                         {
-                            return null;
+                            if (!(arguments.get(i) instanceof COSNumber))
+                            {
+                                return null;
+                            }
                         }
+                        float x = ((COSNumber) arguments.get(2)).floatValue();
+                        float y = ((COSNumber) arguments.get(3)).floatValue();
+                        return new PDRectangle(
+                                x,
+                                y,
+                                ((COSNumber) arguments.get(4)).floatValue() - x,
+                                ((COSNumber) arguments.get(5)).floatValue() - y);
                     }
-                    float x = ((COSNumber) arguments.get(2)).floatValue();
-                    float y = ((COSNumber) arguments.get(3)).floatValue();
-                    return new PDRectangle(
-                            x,
-                            y,
-                            ((COSNumber) arguments.get(4)).floatValue() - x,
-                            ((COSNumber) arguments.get(5)).floatValue() - y);
+                    else
+                    {
+                        return null;
+                    }
                 }
                 else
                 {
-                    return null;
+                    arguments.add((COSBase) token);
                 }
+                token = parser.parseNextToken();
             }
-            else
-            {
-                arguments.add((COSBase) token);
-            }
-            token = parser.parseNextToken();
+            return null;
         }
-        return null;
+        finally
+        {
+            if (parser != null)
+            {
+                parser.close();
+            }
+        }
     }
 
     @Override
@@ -166,19 +177,30 @@ public final class PDType3CharProc implements COSObjectable, PDContentStream
     public float getWidth() throws IOException
     {
         List<COSBase> arguments = new ArrayList<>();
-        PDFStreamParser parser = new PDFStreamParser(this);
-        Object token = parser.parseNextToken();
-        while (token != null)
+        PDFStreamParser parser = null;
+        try
         {
-            if (token instanceof Operator)
+            parser = new PDFStreamParser(this);
+            Object token = parser.parseNextToken();
+            while (token != null)
             {
-                return parseWidth((Operator) token, arguments);
+                if (token instanceof Operator)
+                {
+                    return parseWidth((Operator) token, arguments);
+                }
+                else
+                {
+                    arguments.add((COSBase) token);
+                }
+                token = parser.parseNextToken();
             }
-            else
+        }
+        finally
+        {
+            if (parser != null)
             {
-                arguments.add((COSBase) token);
+                parser.close();
             }
-            token = parser.parseNextToken();
         }
         throw new IOException("Unexpected end of stream");
     }


### PR DESCRIPTION
The PDFStreamParser has a close method. Should it be closed outside or the close method should be protected (private)?