### PR TITLE
extract setCOSValue in PDField.importFDF

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/form/PDChoice.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/form/PDChoice.java
@@ -258,6 +258,19 @@ public abstract class PDChoice extends PDVariableText
         }
     }
 
+    @Override
+    protected void setCOSValue(COSBase fieldValue) throws IOException
+    {
+        if (fieldValue instanceof COSArray)
+        {
+            setValue(((COSArray) fieldValue).toCOSStringStringList());
+        }
+        else
+        {
+            super.setCOSValue(fieldValue);
+        }
+    }
+
     /**
      * Determines if Sort is set.
      * 

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/form/PDField.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/form/PDField.java
@@ -23,8 +23,6 @@ import org.apache.pdfbox.cos.COSArray;
 import org.apache.pdfbox.cos.COSBase;
 import org.apache.pdfbox.cos.COSDictionary;
 import org.apache.pdfbox.cos.COSName;
-import org.apache.pdfbox.cos.COSStream;
-import org.apache.pdfbox.cos.COSString;
 import org.apache.pdfbox.pdmodel.common.COSObjectable;
 import org.apache.pdfbox.pdmodel.fdf.FDFField;
 import org.apache.pdfbox.pdmodel.interactive.action.PDFormFieldAdditionalActions;
@@ -227,6 +225,14 @@ public abstract class PDField implements COSObjectable
         return aa != null ? new PDFormFieldAdditionalActions(aa) : null;
     }
 
+    protected void setCOSValue(COSBase fieldValue) throws IOException
+    {
+        if (fieldValue != null)
+        {
+            dictionary.setItem(COSName.V, fieldValue);
+        }
+    }
+
    /**
      * This will import a fdf field from a fdf document.
      * 
@@ -236,36 +242,8 @@ public abstract class PDField implements COSObjectable
     void importFDF(FDFField fdfField) throws IOException
     {
         COSBase fieldValue = fdfField.getCOSValue();
-        
-        if (fieldValue != null && this instanceof PDTerminalField)
-        {
-            PDTerminalField currentField = (PDTerminalField) this;
-            
-            if (fieldValue instanceof COSName)
-            {
-                currentField.setValue(((COSName) fieldValue).getName());
-            }
-            else if (fieldValue instanceof COSString)
-            {
-                currentField.setValue(((COSString) fieldValue).getString());
-            }
-            else if (fieldValue instanceof COSStream)
-            {
-                currentField.setValue(((COSStream) fieldValue).toTextString());
-            }
-            else if (fieldValue instanceof COSArray && this instanceof PDChoice)
-            {
-                ((PDChoice) this).setValue(((COSArray) fieldValue).toCOSStringStringList());
-            }
-            else
-            {
-                throw new IOException("Error:Unknown type for field import" + fieldValue);
-            }
-        }
-        else if (fieldValue != null)
-        {
-            dictionary.setItem(COSName.V, fieldValue);
-        }
+
+        setCOSValue(fieldValue);
         
         Integer ff = fdfField.getFieldFlags();
         if (ff != null)

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/form/PDTerminalField.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/form/PDTerminalField.java
@@ -23,6 +23,8 @@ import org.apache.pdfbox.cos.COSArray;
 import org.apache.pdfbox.cos.COSBase;
 import org.apache.pdfbox.cos.COSDictionary;
 import org.apache.pdfbox.cos.COSInteger;
+import org.apache.pdfbox.cos.COSString;
+import org.apache.pdfbox.cos.COSStream;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.fdf.FDFField;
 import org.apache.pdfbox.pdmodel.interactive.action.PDFormFieldAdditionalActions;
@@ -93,6 +95,30 @@ public abstract class PDTerminalField extends PDField
             fieldType = getParent().getFieldType();
         }
         return fieldType;
+    }
+
+    @Override
+    protected void setCOSValue(COSBase fieldValue) throws IOException
+    {
+        if (fieldValue != null)
+        {
+            if (fieldValue instanceof COSName)
+            {
+                setValue(((COSName) fieldValue).getName());
+            }
+            else if (fieldValue instanceof COSString)
+            {
+                setValue(((COSString) fieldValue).getString());
+            }
+            else if (fieldValue instanceof COSStream)
+            {
+                setValue(((COSStream) fieldValue).toTextString());
+            }
+            else
+            {
+                throw new IOException("Error:Unknown type for field import" + fieldValue);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
This path excludes mentions of the PDTerminalField and PDChoice types from PDField to make the code more object-oriented. Additionally, the child types will get less checks inside an importFDF(FDFField) method.