### PR TITLE
delete useless calls in COSArray.growToSize method

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/cos/COSArray.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/cos/COSArray.java
@@ -590,7 +590,6 @@ public class COSArray extends COSBase implements Iterable<COSBase>, COSUpdateInf
         while( size() < size )
         {
             add( object );
-            getUpdateState().update(object);
         }
         getUpdateState().update();
     }


### PR DESCRIPTION
The "getUpdateState().update(object);" command will be called inside add(...) method. So, this line is unneeded double call.