### PR TITLE
Fix condition where auto raster dpi is set to zero

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/printing/PDFPrintable.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/printing/PDFPrintable.java
@@ -267,7 +267,7 @@ public final class PDFPrintable implements Printable
             // rasterize to bitmap (optional)
             Graphics2D printerGraphics = null;
             BufferedImage image = null;
-            if (dpi > 0 || dpi == RASTERIZE_DPI_AUTO)
+            if (rasterDpi > 0)
             {
                 LOG.debug("dpi set to {}", rasterDpi);
                 float dpiScale = rasterDpi / 72;


### PR DESCRIPTION
If the auto raster dpi is zero, the code fails when creating the buffered image with the following error:

java.lang.IllegalArgumentException: Width (0) and height (0) cannot be <= 0

This change prevents that. The value of dpi here is always equal to rasterDpi when originally set to RASTERIZE_DPI_AUTO.