### PR TITLE
refactor-PDFTextStripper.writeLine method

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/text/PDFTextStripper.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/text/PDFTextStripper.java
@@ -1858,14 +1858,15 @@ public class PDFTextStripper extends LegacyPDFStreamEngine
             throws IOException
     {
         int numberOfStrings = line.size();
-        for (int i = 0; i < numberOfStrings; i++)
+        int i = 0;
+        for (WordWithTextPositions word : line)
         {
-            WordWithTextPositions word = line.get(i);
             writeString(word.getText(), word.getTextPositions());
             if (i < numberOfStrings - 1)
             {
                 writeWordSeparator();
             }
+            ++i;
         }
     }
 


### PR DESCRIPTION
The normalize method returns an instance of the LinkedList. We use that list inside a writeLine method. The writeLine method uses the list for a loop. The previous version of the loop was slow for a list because each element was retrieved through the get method.

So, there are two ways to fix it:
1 use the foreach statement instead of the for statement
2 use ArrayList instead of LinkedList