### PR TITLE
delete unneeded buffered streams

### DIFF
--- a/fontbox/src/main/java/org/apache/fontbox/ttf/OpenTypeScript.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/OpenTypeScript.java
@@ -16,7 +16,6 @@
  */
 package org.apache.fontbox.ttf;
 
-import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -209,8 +208,7 @@ public final class OpenTypeScript
     static
     {
         String path = "/org/apache/fontbox/unicode/Scripts.txt";
-        try (InputStream resourceAsStream = OpenTypeScript.class.getResourceAsStream(path);
-             InputStream input = new BufferedInputStream(resourceAsStream))
+        try (InputStream input = OpenTypeScript.class.getResourceAsStream(path))
         {
             parseScriptsFile(input);
         }

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/Standard14Fonts.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/Standard14Fonts.java
@@ -134,9 +134,9 @@ public final class Standard14Fonts
         {
             throw new IOException("resource '" + resourceName + "' not found");
         }
-        try (InputStream afmStream = new BufferedInputStream(resourceAsStream))
+        try (resourceAsStream)
         {
-            AFMParser parser = new AFMParser(afmStream);
+            AFMParser parser = new AFMParser(resourceAsStream);
             FontMetrics metric = parser.parse(true);
             FONTS.put(fontName, metric);
         }

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/color/PDDeviceCMYK.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/color/PDDeviceCMYK.java
@@ -107,9 +107,9 @@ public class PDDeviceCMYK extends PDDeviceColorSpace
         {
             throw new IOException("resource '" + resourceName + "' not found");
         }    
-        try (InputStream is = new BufferedInputStream(resourceAsStream))
+        try (resourceAsStream)
         {
-            return ICC_Profile.getInstance(is);
+            return ICC_Profile.getInstance(resourceAsStream);
         }
     }
 

--- a/pdfbox/src/main/java/org/apache/pdfbox/text/PDFTextStripper.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/text/PDFTextStripper.java
@@ -1974,8 +1974,7 @@ public class PDFTextStripper extends LegacyPDFStreamEngine
     static
     {
         String path = "/org/apache/pdfbox/resources/text/BidiMirroring.txt";
-        try (InputStream resourceAsStream = PDFTextStripper.class.getResourceAsStream(path);
-             InputStream input = new BufferedInputStream(resourceAsStream))
+        try (InputStream input = PDFTextStripper.class.getResourceAsStream(path))
         {
             parseBidiFile(input);
         }

--- a/pdfbox/src/main/java/org/apache/pdfbox/util/Version.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/util/Version.java
@@ -47,8 +47,7 @@ public final class Version
      */
     public static String getVersion()
     {
-        try (InputStream resourceAsStream = Version.class.getResourceAsStream(PDFBOX_VERSION_PROPERTIES);
-             InputStream is = new BufferedInputStream(resourceAsStream))
+        try (InputStream is = Version.class.getResourceAsStream(PDFBOX_VERSION_PROPERTIES))
         {
             Properties properties = new Properties();
             properties.load(is);


### PR DESCRIPTION
I did a little research and realized that these streams are already buffered. It's possible that in some very old SDK versions they won't be buffered. In my opinion, it's best to only instantiate a BufferedInputStream if the current stream is unbuffered. I mean, if you'd like then I can add the check is this BufferedInputStream and wrap current stream if not. In the current implementation in the library, we're experiencing double synchronization due to the double wrapping of the BufferedInputStream. 