### PR TITLE
refactor TextToPDF.call method

### DIFF
--- a/tools/src/main/java/org/apache/pdfbox/tools/TextToPDF.java
+++ b/tools/src/main/java/org/apache/pdfbox/tools/TextToPDF.java
@@ -20,7 +20,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
+import java.io.BufferedInputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.io.Reader;
@@ -185,23 +185,30 @@ public class TextToPDF implements Callable<Integer>
             setTopMargin(margins[2]);
             setBottomMargin(margins[3]);
 
-            try (InputStream is = new FileInputStream(infile))
+            try (BufferedInputStream is = new BufferedInputStream(new FileInputStream(infile)))
             {
                 if (charset.equals(StandardCharsets.UTF_8))
                 {
-                    try
+                    final int readLimit = 3;
+                    is.mark(readLimit);
+
+                    byte[] firstBytes = new byte[readLimit];
+                    if (is.read(firstBytes) != readLimit)
                     {
-                        // check for utf8 BOM
-                        // FileInputStream doesn't support mark/reset
-                        int b1 = is.read();
-                        int b2 = is.read();
-                        int b3 = is.read();
-                        //todo Here we can perform a check for file format corruption here.
-                        boolean hasUtf8BOM = b1 == 0xEF && b2 == 0xBB && b3 == 0xBF;
+                        throw new IOException("Could not read 3 bytes, size changed?!");
                     }
-                    catch (IOException x)
+
+                    if (firstBytes[0] == (byte) 0xEF &&
+                        firstBytes[1] == (byte) 0xBB &&
+                        firstBytes[2] == (byte) 0xBF)
                     {
-                        throw new IOException("Could not skip 3 bytes, size changed?!");
+                        //UTF-8 with BOM
+                        //3 bytes already read (skipped)
+                    }
+                    else
+                    {
+                        //It looks like UTF with no BOM or file was corrupted
+                        is.reset();
                     }
                 }
                 try (Reader reader = new InputStreamReader(is, charset))

--- a/tools/src/main/java/org/apache/pdfbox/tools/TextToPDF.java
+++ b/tools/src/main/java/org/apache/pdfbox/tools/TextToPDF.java
@@ -185,25 +185,21 @@ public class TextToPDF implements Callable<Integer>
             setTopMargin(margins[2]);
             setBottomMargin(margins[3]);
 
-            boolean hasUtf8BOM = false;
-            if (charset.equals(StandardCharsets.UTF_8))
-            {
-                // check for utf8 BOM
-                // FileInputStream doesn't support mark/reset
-                try (InputStream is = new FileInputStream(infile))
-                {
-                    if (is.read() == 0xEF && is.read() == 0xBB && is.read() == 0xBF)
-                    {
-                        hasUtf8BOM = true;
-                    }
-                }
-            }
             try (InputStream is = new FileInputStream(infile))
             {
-                if (hasUtf8BOM)
+                if (charset.equals(StandardCharsets.UTF_8))
                 {
-                    long skipped = is.skip(3);
-                    if (skipped != 3)
+                    try
+                    {
+                        // check for utf8 BOM
+                        // FileInputStream doesn't support mark/reset
+                        int b1 = is.read();
+                        int b2 = is.read();
+                        int b3 = is.read();
+                        //todo Here we can perform a check for file format corruption here.
+                        boolean hasUtf8BOM = b1 == 0xEF && b2 == 0xBB && b3 == 0xBF;
+                    }
+                    catch (IOException x)
                     {
                         throw new IOException("Could not skip 3 bytes, size changed?!");
                     }


### PR DESCRIPTION
Current algorithm is:
1 if charset is UTF8 then read 3 bytes.
2 if these 3 bytes have expected values then mark a hasUtf8BOM variable as true
3 close stream
4 open new stream of the same file
5 if the variable hasUtf8BOM is true then skip 3 bytes.
6 if couldn't skip 3 bytes then throw an exception
7 If bytes were skipped or there is no need to skip them, the rest of the file should be read.

These are questions not for you, but for the algorithm:
1 why we need read the file twice when it increases the likelihood that we won't succeed the second time?
2 Opening a stream twice is slower than opening it once.
3 According to the code, there's a possibility that we couldn't read the file a second time. Then why isn't there a check to see if the file is corrupted? That is, it's UTF-8 encoding, but what if one or two of these three bytes are different. Perhaps the format has such combinations that this can't be verified.

At this point, I propose making one stream instead of two. There are no other changes.