### PR TITLE
add null check in ImageIOUtil.writeImage method

### DIFF
--- a/tools/src/main/java/org/apache/pdfbox/tools/imageio/ImageIOUtil.java
+++ b/tools/src/main/java/org/apache/pdfbox/tools/imageio/ImageIOUtil.java
@@ -311,8 +311,15 @@ public final class ImageIOUtil
 
             // write
             imageOutput = ImageIO.createImageOutputStream(output);
-            writer.setOutput(imageOutput);
-            writer.write(null, new IIOImage(image, null, metadata), param);
+            if (imageOutput != null)
+            {
+                writer.setOutput(imageOutput);
+                writer.write(null, new IIOImage(image, null, metadata), param);
+            }
+            else
+            {
+                return false;
+            }
         }
         finally
         {


### PR DESCRIPTION
In the documentation of the method ImageIO.createImageOutputStream is written "it returns an ImageOutputStream, or null."