### PR TITLE
Fix ClassCastException in PDInlineImage.getDecode()

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/PDInlineImage.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/PDInlineImage.java
@@ -278,7 +278,12 @@ public final class PDInlineImage implements PDImage
     @Override
     public COSArray getDecode()
     {
-        return (COSArray) parameters.getDictionaryObject(COSName.D, COSName.DECODE);
+        COSBase decode = parameters.getDictionaryObject(COSName.D, COSName.DECODE);
+        if (decode instanceof COSArray)
+        {
+            return (COSArray) decode;
+        }
+        return null;
     }
 
     @Override

--- a/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/graphics/image/PDInlineImageTest.java
+++ b/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/graphics/image/PDInlineImageTest.java
@@ -192,7 +192,56 @@ class PDInlineImageTest
         }
     }
 
-    // 3 Tests for PDFBOX-5360 with very small images (the last one based on a comment 
+    /**
+     * Tests that getDecode() does not throw ClassCastException when the /D parameter
+     * is a non-array type (e.g., integer). Malformed PDFs may provide an integer or
+     * other type instead of a COSArray for the Decode parameter.
+     */
+    @Test
+    void testGetDecodeWithInvalidType() throws IOException
+    {
+        // Test 1: /D set to integer (should return null, not throw ClassCastException)
+        COSDictionary dict = new COSDictionary();
+        dict.setBoolean(COSName.IM, true);
+        dict.setInt(COSName.W, 1);
+        dict.setInt(COSName.H, 1);
+        dict.setInt(COSName.BPC, 1);
+        dict.setInt(COSName.D, 123); // wrong type: integer instead of array
+
+        byte[] data = new byte[]{0};
+        PDInlineImage inlineImage = new PDInlineImage(dict, data, null);
+        Assertions.assertNull(inlineImage.getDecode(),
+                "getDecode() should return null for non-array /D value");
+
+        // Test 2: /D set to valid COSArray (should still work)
+        COSDictionary dict2 = new COSDictionary();
+        dict2.setBoolean(COSName.IM, true);
+        dict2.setInt(COSName.W, 1);
+        dict2.setInt(COSName.H, 1);
+        dict2.setInt(COSName.BPC, 1);
+        COSArray decodeArray = new COSArray();
+        decodeArray.add(COSInteger.ONE);
+        decodeArray.add(COSInteger.ZERO);
+        dict2.setItem(COSName.D, decodeArray);
+
+        PDInlineImage inlineImage2 = new PDInlineImage(dict2, data, null);
+        Assertions.assertNotNull(inlineImage2.getDecode(),
+                "getDecode() should return array for valid /D value");
+        Assertions.assertEquals(2, inlineImage2.getDecode().size());
+
+        // Test 3: /D not set (should return null)
+        COSDictionary dict3 = new COSDictionary();
+        dict3.setBoolean(COSName.IM, true);
+        dict3.setInt(COSName.W, 1);
+        dict3.setInt(COSName.H, 1);
+        dict3.setInt(COSName.BPC, 1);
+
+        PDInlineImage inlineImage3 = new PDInlineImage(dict3, data, null);
+        Assertions.assertNull(inlineImage3.getDecode(),
+                "getDecode() should return null when /D is not set");
+    }
+
+    // 3 Tests for PDFBOX-5360 with very small images (the last one based on a comment
     // by Oliver Schmidtmer at the end of PDFBOX-5340). All images are fully black bars.
 
     @Test


### PR DESCRIPTION
# Type Confusion in PDInlineImage.getDecode() - ClassCastException

## Summary

PDInlineImage.getDecode() in Apache PDFBox performs an unsafe type cast from `COSBase` to `COSArray` without validation. When a malformed PDF provides a non-array value for the `/D` (Decode) parameter, the cast fails with `ClassCastException`, causing application crash during PDF rendering operations.

**Type**: Type Confusion (CWE-843)
**Severity**: Medium (CVSS ~4.3)
**Impact**: Denial of Service (application crash during PDF processing)
**Affected Component**: `pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/PDInlineImage.java:281`

## Root Cause

### Vulnerable Code (PDInlineImage.java:281)

```java
@Override
public COSArray getDecode()
{
    return (COSArray) parameters.getDictionaryObject(COSName.D, COSName.DECODE);
}
```

Unsafe cast from `COSBase` to `COSArray` without type validation. When a malformed PDF provides a non-array value (integer, name, string, or dictionary) for the `/D` parameter, the cast throws `ClassCastException`. The sibling class `PDImageXObject.getDecode()` uses the safe `getCOSArray()` pattern with `instanceof` check.

## PoC

### Trigger file

A crafted `malicious_inline.pdf` (474 bytes) containing an inline image with `/D` set to integer instead of array:

```
BI
/W 1
/H 1
/CS /DeviceRGB
/D 123          <- Should be array [0 1], but is integer
ID
ABC EI
```

### How to generate malicious_inline.pdf

```python
# create_malicious_pdf_inline.py
pdf = b"""%PDF-1.4
1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj
3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]/Contents 4 0 R>>endobj
4 0 obj
<</Length 45>>
stream
 BI
/W 1
/H 1
/CS /DeviceRGB
/D 123
ID
ABC EI
endstream
endobj
xref
0 5
0000000000 65535 f
0000000009 00000 n
0000000058 00000 n
0000000115 00000 n
0000000214 00000 n
trailer<</Size 5/Root 1 0 R>>
startxref
309
%%EOF"""
with open("malicious_inline.pdf", "wb") as f:
    f.write(pdf)
```

```bash
python3 create_malicious_pdf_inline.py
```

---

## Trigger Method 1: Official pdfbox-app CLI

```bash
java -jar pdfbox-app-4.0.0-SNAPSHOT.jar render -i malicious_inline.pdf -prefix output
```

**Output:**
```
java.lang.ClassCastException: class org.apache.pdfbox.cos.COSInteger cannot be cast to class org.apache.pdfbox.cos.COSArray
	at org.apache.pdfbox.pdmodel.graphics.image.PDInlineImage.getDecode(PDInlineImage.java:281)
	at org.apache.pdfbox.pdmodel.graphics.image.SampledImageReader.getDecodeArray(SampledImageReader.java:743)
	at org.apache.pdfbox.pdmodel.graphics.image.SampledImageReader.getRGBImage(SampledImageReader.java:206)
	at org.apache.pdfbox.pdmodel.graphics.image.SampledImageReader.getRGBImage(SampledImageReader.java:138)
	at org.apache.pdfbox.pdmodel.graphics.image.PDInlineImage.getImage(PDInlineImage.java:350)
	at org.apache.pdfbox.rendering.PageDrawer.drawImage(PageDrawer.java:1108)
```

**Note**: Text extraction (`export:text`) does NOT trigger the bug, only rendering operations.

---

## Trigger Method 2: Direct API

```java
import org.apache.pdfbox.cos.*;
import org.apache.pdfbox.pdmodel.graphics.image.PDInlineImage;

public class Reproduce {
    public static void main(String[] args) throws Exception {
        COSDictionary params = new COSDictionary();
        params.setInt(COSName.W, 1);
        params.setInt(COSName.H, 1);
        params.setName(COSName.CS, "DeviceRGB");
        params.setInt(COSName.D, 123);  // wrong type: integer instead of array

        PDInlineImage image = new PDInlineImage(params, new byte[]{0,0,0}, null);
        image.getDecode();  // ClassCastException
    }
}
```

---

## Impact

| Aspect | Details |
|--------|---------|
| **Type** | Denial of Service (DoS) |
| **Severity** | Medium |
| **Attack Vector** | Malicious PDF with malformed inline image |
| **Affected Operations** | PDF rendering, PDF/A conversion, thumbnail generation |
| **Not Affected** | Text extraction (getDecode() not called) |
| **CWE** | CWE-843 (Access of Resource Using Incompatible Type) |

---