### PR TITLE
Fix NegativeArraySizeException in PfbParser

### DIFF
--- a/fontbox/src/main/java/org/apache/fontbox/pfb/PfbParser.java
+++ b/fontbox/src/main/java/org/apache/fontbox/pfb/PfbParser.java
@@ -154,7 +154,7 @@ public class PfbParser
             size += in.read() << 16;
             size += in.read() << 24;
             LOG.debug("record type: {}, segment size: {}", recordType, size);
-            if (size > pfb.length)
+            if (size < 0 || size > pfb.length)
             {
                 // PDFBOX-6044: avoid potential OOM
                 throw new IOException("record size " + size + " would be larger than the input");

--- a/fontbox/src/test/java/org/apache/fontbox/pfb/PfbParserTest.java
+++ b/fontbox/src/test/java/org/apache/fontbox/pfb/PfbParserTest.java
@@ -101,4 +101,25 @@ class PfbParserTest
     {
         Assertions.assertThrows(IOException.class, () -> Type1Font.createWithPFB(new byte[0]));
     }
+
+    /**
+     * Test that a PFB with a negative size field (integer overflow) throws IOException
+     * instead of NegativeArraySizeException. A crafted 18-byte PFB with size bytes
+     * 01 00 00 FF overflows the signed int to -16777215, bypassing the upper-bound check.
+     */
+    @Test
+    void testNegativeRecordSize()
+    {
+        // 18-byte crafted PFB: start marker 0x80, ASCII type 0x01,
+        // size field 0x01 0x00 0x00 0xFF = -16777215 as signed int
+        byte[] crashInput = {
+            (byte) 0x80, 0x01,                         // header
+            0x01, 0x00, 0x00, (byte) 0xFF,             // size: overflows to negative
+            (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,     // garbage data
+            (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
+            0x27, 0x05, (byte) 0xF8, (byte) 0xFF,
+            (byte) 0xD2, 0x40
+        };
+        Assertions.assertThrows(IOException.class, () -> new PfbParser(crashInput));
+    }
 }


### PR DESCRIPTION
# NegativeArraySizeException in PfbParser due to Integer Overflow

## Summary

PfbParser in Apache PDFBox's fontbox component reads a 4-byte size field as a signed integer without validating for negative values. When processing a malformed PFB font, integer overflow causes a negative size value, leading to `NegativeArraySizeException` and application crash.

**Type**: Integer Overflow (CWE-190)
**Severity**: Medium (CVSS ~5.5)
**Impact**: Denial of Service (application crash)
**Affected Component**: `fontbox/src/main/java/org/apache/fontbox/pfb/PfbParser.java:162`

## Root Cause

### Vulnerable Code (PfbParser.java:152-162)

```java
int size = in.read();
size += in.read() << 8;
size += in.read() << 16;
size += in.read() << 24;          // signed integer overflow
LOG.debug("record type: {}, segment size: {}", recordType, size);
if (size > pfb.length)            // only checks upper bound
{
    // PDFBOX-6044: avoid potential OOM
    throw new IOException("record size " + size + " would be larger than the input");
}
byte[] ar = new byte[size];       // line 162: CRASH with negative size
```

When the 4th byte of the size field is >= 0x80, Java's signed integer arithmetic causes overflow to negative. The PDFBOX-6044 bounds check `size > pfb.length` only validates the upper bound — negative values pass through and crash at array allocation.

## PoC

### Trigger file

A crafted `malicious_pfb.pdf` with an embedded Type1 font containing an 18-byte PFB payload with size field `01 00 00 FF` that overflows to -16777215.

### How to generate crash.bin

```bash
echo -n "gAEBAAD/////////JwX4/9JA" | base64 -d > crash.bin
```

**Hex structure** (18 bytes):
```
80 01 01 00 00 ff ff ff ff ff ff ff 27 05 f8 ff d2 40
```

- `0x80` — Start marker
- `0x01` — ASCII segment type
- `01 00 00 FF` — Size field (little-endian), overflows to -16777215
- Rest — Garbage data

### How to generate malicious_pfb.pdf

```bash
python3 create_malicious_pdf_pfb.py
```

---

## Trigger Method 1: Official pdfbox-app CLI

```bash
java -jar pdfbox-app-4.0.0-SNAPSHOT.jar export:text -i malicious_pfb.pdf -o output.txt
```

**Output:**
```
java.lang.NegativeArraySizeException: -16777215
	at org.apache.fontbox.pfb.PfbParser.parsePfb(PfbParser.java:162)
	at org.apache.fontbox.pfb.PfbParser.<init>(PfbParser.java:112)
	at org.apache.fontbox.type1.Type1Font.createWithPFB(Type1Font.java:69)
	at org.apache.pdfbox.pdmodel.font.PDType1Font.<init>(PDType1Font.java:227)
	at org.apache.pdfbox.pdmodel.font.PDFontFactory.createFont(PDFontFactory.java:140)
	at org.apache.pdfbox.pdmodel.PDResources.getFont(PDResources.java:170)
```

**Note**: `NegativeArraySizeException` is a `RuntimeException`, not caught by `PDType1Font` which only catches `IOException` and `DamagedFontException`.

---

## Trigger Method 2: Direct API

```java
import org.apache.fontbox.pfb.PfbParser;
import java.util.Base64;

public class Reproduce {
    public static void main(String[] args) throws Exception {
        byte[] crash = Base64.getDecoder().decode("gAEBAAD/////////JwX4/9JA");
        new PfbParser(crash);  // NegativeArraySizeException: -16777215
    }
}
```
