### PR TITLE
Improve directory boundary check in ExtractEmbeddedFiles example

### DIFF
--- a/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/ExtractEmbeddedFiles.java
+++ b/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/ExtractEmbeddedFiles.java
@@ -141,7 +141,9 @@ public final class ExtractEmbeddedFiles
     {
         File file = new File(directoryPath, filename);
         File parentDir = file.getParentFile();
-        if (!parentDir.getCanonicalPath().startsWith(directoryPath))
+        String parentCanonical = parentDir.getCanonicalPath();
+        if (!parentCanonical.equals(directoryPath)
+            && !parentCanonical.startsWith(directoryPath + File.separator))
         {
             System.err.println("Ignoring " + filename + " (different directory)");
             return;


### PR DESCRIPTION
Improve directory boundary check in ExtractEmbeddedFiles example