### PR TITLE
introduce private method to remove clones

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDAbstractContentStream.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDAbstractContentStream.java
@@ -417,10 +417,7 @@ abstract class PDAbstractContentStream implements Closeable
      */
     public void drawImage(PDImageXObject image, float x, float y, float width, float height) throws IOException
     {
-        if (inTextMode)
-        {
-            throw new IllegalStateException("Error: drawImage is not allowed within a text block.");
-        }
+        assertNotInTextMode("drawImage");
 
         saveGraphicsState();
 
@@ -444,10 +441,7 @@ abstract class PDAbstractContentStream implements Closeable
      */
     public void drawImage(PDImageXObject image, Matrix matrix) throws IOException
     {
-        if (inTextMode)
-        {
-            throw new IllegalStateException("Error: drawImage is not allowed within a text block.");
-        }
+        assertNotInTextMode("drawImage");
 
         saveGraphicsState();
 
@@ -488,10 +482,7 @@ abstract class PDAbstractContentStream implements Closeable
      */
     public void drawImage(PDInlineImage inlineImage, float x, float y, float width, float height) throws IOException
     {
-        if (inTextMode)
-        {
-            throw new IllegalStateException("Error: drawImage is not allowed within a text block.");
-        }
+        assertNotInTextMode("drawImage");
 
         saveGraphicsState();
         transform(new Matrix(width, 0, 0, height, x, y));
@@ -553,10 +544,7 @@ abstract class PDAbstractContentStream implements Closeable
      */
     public void drawForm(PDFormXObject form) throws IOException
     {
-        if (inTextMode)
-        {
-            throw new IllegalStateException("Error: drawForm is not allowed within a text block.");
-        }
+        assertNotInTextMode("drawForm");
 
         writeOperand(resources.add(form));
         writeOperator(OperatorName.DRAW_OBJECT);
@@ -899,10 +887,7 @@ abstract class PDAbstractContentStream implements Closeable
      */
     public void addRect(float x, float y, float width, float height) throws IOException
     {
-        if (inTextMode)
-        {
-            throw new IllegalStateException("Error: addRect is not allowed within a text block.");
-        }
+        assertNotInTextMode("addRect");
         writeOperand(x);
         writeOperand(y);
         writeOperand(width);
@@ -925,10 +910,7 @@ abstract class PDAbstractContentStream implements Closeable
      */
     public void curveTo(float x1, float y1, float x2, float y2, float x3, float y3) throws IOException
     {
-        if (inTextMode)
-        {
-            throw new IllegalStateException("Error: curveTo is not allowed within a text block.");
-        }
+        assertNotInTextMode("curveTo");
         writeOperand(x1);
         writeOperand(y1);
         writeOperand(x2);
@@ -951,10 +933,7 @@ abstract class PDAbstractContentStream implements Closeable
      */
     public void curveTo2(float x2, float y2, float x3, float y3) throws IOException
     {
-        if (inTextMode)
-        {
-            throw new IllegalStateException("Error: curveTo2 is not allowed within a text block.");
-        }
+        assertNotInTextMode("curveTo2");
         writeOperand(x2);
         writeOperand(y2);
         writeOperand(x3);
@@ -975,10 +954,7 @@ abstract class PDAbstractContentStream implements Closeable
      */
     public void curveTo1(float x1, float y1, float x3, float y3) throws IOException
     {
-        if (inTextMode)
-        {
-            throw new IllegalStateException("Error: curveTo1 is not allowed within a text block.");
-        }
+        assertNotInTextMode("curveTo1");
         writeOperand(x1);
         writeOperand(y1);
         writeOperand(x3);
@@ -996,10 +972,7 @@ abstract class PDAbstractContentStream implements Closeable
      */
     public void moveTo(float x, float y) throws IOException
     {
-        if (inTextMode)
-        {
-            throw new IllegalStateException("Error: moveTo is not allowed within a text block.");
-        }
+        assertNotInTextMode("moveTo");
         writeOperand(x);
         writeOperand(y);
         writeOperator(OperatorName.MOVE_TO);
@@ -1015,10 +988,7 @@ abstract class PDAbstractContentStream implements Closeable
      */
     public void lineTo(float x, float y) throws IOException
     {
-        if (inTextMode)
-        {
-            throw new IllegalStateException("Error: lineTo is not allowed within a text block.");
-        }
+        assertNotInTextMode("lineTo");
         writeOperand(x);
         writeOperand(y);
         writeOperator(OperatorName.LINE_TO);
@@ -1032,10 +1002,7 @@ abstract class PDAbstractContentStream implements Closeable
      */
     public void stroke() throws IOException
     {
-        if (inTextMode)
-        {
-            throw new IllegalStateException("Error: stroke is not allowed within a text block.");
-        }
+        assertNotInTextMode("stroke");
         writeOperator(OperatorName.STROKE_PATH);
     }
 
@@ -1047,10 +1014,7 @@ abstract class PDAbstractContentStream implements Closeable
      */
     public void closeAndStroke() throws IOException
     {
-        if (inTextMode)
-        {
-            throw new IllegalStateException("Error: closeAndStroke is not allowed within a text block.");
-        }
+        assertNotInTextMode("closeAndStroke");
         writeOperator(OperatorName.CLOSE_AND_STROKE);
     }
 
@@ -1062,10 +1026,7 @@ abstract class PDAbstractContentStream implements Closeable
      */
     public void fill() throws IOException
     {
-        if (inTextMode)
-        {
-            throw new IllegalStateException("Error: fill is not allowed within a text block.");
-        }
+        assertNotInTextMode("fill");
         writeOperator(OperatorName.FILL_NON_ZERO);
     }
 
@@ -1077,10 +1038,7 @@ abstract class PDAbstractContentStream implements Closeable
      */
     public void fillEvenOdd() throws IOException
     {
-        if (inTextMode)
-        {
-            throw new IllegalStateException("Error: fillEvenOdd is not allowed within a text block.");
-        }
+        assertNotInTextMode("fillEvenOdd");
         writeOperator(OperatorName.FILL_EVEN_ODD);
     }
 
@@ -1094,10 +1052,7 @@ abstract class PDAbstractContentStream implements Closeable
      */
     public void fillAndStroke() throws IOException
     {
-        if (inTextMode)
-        {
-            throw new IllegalStateException("Error: fillAndStroke is not allowed within a text block.");
-        }
+        assertNotInTextMode("fillAndStroke");
         writeOperator(OperatorName.FILL_NON_ZERO_AND_STROKE);
     }
 
@@ -1111,10 +1066,7 @@ abstract class PDAbstractContentStream implements Closeable
      */
     public void fillAndStrokeEvenOdd() throws IOException
     {
-        if (inTextMode)
-        {
-            throw new IllegalStateException("Error: fillAndStrokeEvenOdd is not allowed within a text block.");
-        }
+        assertNotInTextMode("fillAndStrokeEvenOdd");
         writeOperator(OperatorName.FILL_EVEN_ODD_AND_STROKE);
     }
 
@@ -1128,10 +1080,7 @@ abstract class PDAbstractContentStream implements Closeable
      */
     public void closeAndFillAndStroke() throws IOException
     {
-        if (inTextMode)
-        {
-            throw new IllegalStateException("Error: closeAndFillAndStroke is not allowed within a text block.");
-        }
+        assertNotInTextMode("closeAndFillAndStroke");
         writeOperator(OperatorName.CLOSE_FILL_NON_ZERO_AND_STROKE);
     }
 
@@ -1145,10 +1094,7 @@ abstract class PDAbstractContentStream implements Closeable
      */
     public void closeAndFillAndStrokeEvenOdd() throws IOException
     {
-        if (inTextMode)
-        {
-            throw new IllegalStateException("Error: closeAndFillAndStrokeEvenOdd is not allowed within a text block.");
-        }
+        assertNotInTextMode("closeAndFillAndStrokeEvenOdd");
         writeOperator(OperatorName.CLOSE_FILL_EVEN_ODD_AND_STROKE);
     }
 
@@ -1161,10 +1107,7 @@ abstract class PDAbstractContentStream implements Closeable
      */
     public void shadingFill(PDShading shading) throws IOException
     {
-        if (inTextMode)
-        {
-            throw new IllegalStateException("Error: shadingFill is not allowed within a text block.");
-        }
+        assertNotInTextMode("shadingFill");
 
         writeOperand(resources.add(shading));
         writeOperator(OperatorName.SHADING_FILL);
@@ -1178,10 +1121,7 @@ abstract class PDAbstractContentStream implements Closeable
      */
     public void closePath() throws IOException
     {
-        if (inTextMode)
-        {
-            throw new IllegalStateException("Error: closePath is not allowed within a text block.");
-        }
+        assertNotInTextMode("closePath");
         writeOperator(OperatorName.CLOSE_PATH);
     }
 
@@ -1193,10 +1133,7 @@ abstract class PDAbstractContentStream implements Closeable
      */
     public void clip() throws IOException
     {
-        if (inTextMode)
-        {
-            throw new IllegalStateException("Error: clip is not allowed within a text block.");
-        }
+        assertNotInTextMode("clip");
         writeOperator(OperatorName.CLIP_NON_ZERO);
         
         // end path without filling or stroking
@@ -1211,10 +1148,7 @@ abstract class PDAbstractContentStream implements Closeable
      */
     public void clipEvenOdd() throws IOException
     {
-        if (inTextMode)
-        {
-            throw new IllegalStateException("Error: clipEvenOdd is not allowed within a text block.");
-        }
+        assertNotInTextMode("clipEvenOdd");
         writeOperator(OperatorName.CLIP_EVEN_ODD);
         
         // end path without filling or stroking
@@ -1567,6 +1501,15 @@ abstract class PDAbstractContentStream implements Closeable
     private boolean isOutsideOneInterval(double val)
     {
         return val < 0 || val > 1;
+    }
+
+    private void assertNotInTextMode(String operation)
+    {
+        if (inTextMode)
+        {
+            throw new IllegalStateException(
+                    "Error: " + operation + " is not allowed within a text block.");
+        }
     }
 
     protected void setStrokingColorSpaceStack(PDColorSpace colorSpace)


### PR DESCRIPTION
use _assertNotInTextMode_ to simplify error handling.