### PR TITLE
refactor-COSWriterCompressionPool.addStructure

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdfwriter/compress/COSWriterCompressionPool.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdfwriter/compress/COSWriterCompressionPool.java
@@ -196,9 +196,8 @@ public class COSWriterCompressionPool
     {
         COSBase base = current;
         if (!current.isDirect() && //
-                (current instanceof COSStream //
-                        || current instanceof COSDictionary //
-                        || current instanceof COSArray))
+                (current instanceof COSDictionary
+                 || current instanceof COSArray))
         {
             base = addObjectToPool(base.getKey(), current);
         }


### PR DESCRIPTION
COSStream is already a COSDictionary. Therefore, no additional validation is required for COSStream.