### PR TITLE
change a message for log in ASCIIHexFilter.decode method

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/filter/ASCIIHexFilter.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/filter/ASCIIHexFilter.java
@@ -82,7 +82,7 @@ final class ASCIIHexFilter extends Filter
        
             if (REVERSE_HEX[firstByte] == -1)
             {
-                LOG.error("Invalid hex, int: {} char: {}", firstByte, (char) firstByte);
+                LOG.error("Invalid hex, int: {} char: {} (1st byte)", firstByte, (char) firstByte);
             }
             value = REVERSE_HEX[firstByte] * 16;
             secondByte = encoded.read();
@@ -95,7 +95,7 @@ final class ASCIIHexFilter extends Filter
             }
             if (REVERSE_HEX[secondByte] == -1)
             {
-                LOG.error("Invalid hex, int: {} char: {}", secondByte, (char) secondByte);
+                LOG.error("Invalid hex, int: {} char: {} (2nd byte)", secondByte, (char) secondByte);
             }
             value += REVERSE_HEX[secondByte];
             decoded.write(value);


### PR DESCRIPTION
Fixed a warning that two logs contain the same message.