### PR TITLE
Fix ccittfactory.readlong v2

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/CCITTFactory.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/CCITTFactory.java
@@ -306,7 +306,7 @@ public final class CCITTFactory
             {
                 int tag = readshort(endianess, reader);
                 int type = readshort(endianess, reader);
-                int count = readlong(endianess, reader);
+                int count = (int) readlong(endianess, reader);
                 int val;
                 // Note that when the type is shorter than 4 bytes, the rest can be garbage
                 // and must be ignored. E.g. short (2 bytes) from "01 00 38 32" (little endian)
@@ -325,7 +325,7 @@ public final class CCITTFactory
                         reader.read();
                         break;
                     default: // long and other types
-                        val = readlong(endianess, reader);
+                        val = (int) readlong(endianess, reader);
                         break;
                 }
                 switch (tag)
@@ -475,13 +475,14 @@ public final class CCITTFactory
         return (raf.read() << 8) | raf.read();
     }
 
-    private static int readlong(char endianess, RandomAccessRead raf) throws IOException
+    static long readlong(char endianess, RandomAccessRead raf) throws IOException
     {
+        // TIFF LONG is an unsigned 32-bit value; mask so it widens correctly
         if (endianess == 'I')
         {
-            return raf.read() | (raf.read() << 8) | (raf.read() << 16) | (raf.read() << 24);
+            return (raf.read() | (raf.read() << 8) | (raf.read() << 16) | (raf.read() << 24)) & 0xFFFFFFFFL;
         }
-        return (raf.read() << 24) | (raf.read() << 16) | (raf.read() << 8) | raf.read();
+        return ((raf.read() << 24) | (raf.read() << 16) | (raf.read() << 8) | raf.read()) & 0xFFFFFFFFL;
     }
 
     private static final byte[] fliptable = new byte[]

--- a/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/graphics/image/CCITTFactoryTest.java
+++ b/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/graphics/image/CCITTFactoryTest.java
@@ -32,6 +32,8 @@ import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import javax.imageio.stream.ImageInputStream;
 
+import org.apache.pdfbox.io.RandomAccessRead;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -314,6 +316,42 @@ class CCITTFactoryTest
         try (PDDocument document = Loader.loadPDF(new File(TESTRESULTSDIR, "Wing.pdf")))
         {
             assertEquals(1, document.getNumberOfPages());
+        }
+    }
+
+    /**
+     * Tests that CCITTFactory's private readlong() reads a TIFF LONG as an unsigned 32-bit
+     * value. The previous implementation returned a (possibly negative) int, which was then
+     * sign-extended when widened to long, corrupting IFD offsets/counts whose high bit is set
+     * (e.g. 0x80000000 and above).
+     */
+    @Test
+    void testReadLongIsUnsigned() throws Exception
+    {
+        // all bits set: 0xFFFFFFFF == 4294967295 as an unsigned TIFF LONG.
+        // The buggy code returned the int -1, which as a long is -1, not 4294967295.
+        byte[] allOnes = { (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF };
+        assertReadLongUnsigned('I', allOnes, 0xFFFFFFFFL);
+        assertReadLongUnsigned('M', allOnes, 0xFFFFFFFFL);
+
+        // only the top bit set, in each byte order: 0x80000000 == 2147483648 unsigned.
+        // The buggy code returned the int Integer.MIN_VALUE, which sign-extends to a
+        // large negative long instead of 2147483648.
+        byte[] littleEndianTopBit = { 0x00, 0x00, 0x00, (byte) 0x80 };
+        assertReadLongUnsigned('I', littleEndianTopBit, 0x80000000L);
+
+        byte[] bigEndianTopBit = { (byte) 0x80, 0x00, 0x00, 0x00 };
+        assertReadLongUnsigned('M', bigEndianTopBit, 0x80000000L);
+    }
+
+    private static void assertReadLongUnsigned(char endianess, byte[] bytes,
+                                               long expected) throws Exception
+    {
+        try (RandomAccessRead raf = new RandomAccessReadBuffer(bytes))
+        {
+            long value = CCITTFactory.readlong(endianess, raf);
+            assertEquals(expected, value);
+            assertTrue(value >= 0, "TIFF LONG must be read as unsigned, not sign-extended");
         }
     }
 }


### PR DESCRIPTION
Summary
CCITTFactory.readlong() reads a TIFF LONG field (an unsigned 32-bit value per the TIFF spec) by assembling four bytes with an int, then returning that int. At the call site (long address = readlong(...)), the int is widened to long, which in Java sign-extends. If the top bit of the 32-bit value is set (i.e. the raw value is >= 0x80000000), the widened long becomes a large negative number instead of the correct unsigned value — corrupting IFD offsets used directly in reader.seek(address).

In practice this is latent rather than commonly hit: classic TIFF (non-BigTIFF) is capped near 4GB by its own 32-bit offset fields, and CCITT G3/G4-compressed files in particular are typically KB-to-low-MB in size, so authentic offsets essentially never cross that boundary. The realistic risk is a malformed/corrupted/adversarial TIFF whose 4-byte offset or count field has the high bit set — readlong trusts those bytes without validating against the actual file size, so such input silently produces a corrupted negative seek target rather than a controlled error.

Fix
fix warning for readlong method
readlong now returns long and masks the assembled value with & 0xFFFFFFFFL, so it's always treated as unsigned when read.
address (already declared long) now receives the correct unsigned value automatically.
count and val, which are intentionally kept as int (small tag values used with params.setInt(...) / buffer sizes), now narrow explicitly via (int) casts — same bit pattern as before, so their behavior is unchanged.
Test plan
Added CCITTFactoryTest#testReadLongIsUnsigned, which invokes the private readlong via reflection against crafted byte sequences with the high bit set (0xFFFFFFFF and 0x80000000, in both byte orders) and asserts the returned long is the correct non-negative unsigned value.

Verified the test fails against the pre-fix int-returning implementation (e.g. expected 4294967295, got -1) and passes against the fix.
Existing CCITTFactoryTest suite (small real-world CCITT G3/G4 fixtures) continues to pass — those files never exercised this path since their offsets are well under 0x80000000.

----------------------------------------------------------------

Per https://www.apache.org/legal/generative-tooling.html: portions of this PR (the `readlong()` fix in
`CCITTFactory.java` and the accompanying `CCITTFactoryTest#testReadLongIsUnsigned` regression test) were
produced with assistance from Claude Code (Anthropic), based on a bug I identified and directed the fix for.

I've reviewed the generated code and test, verified the test fails against the pre-fix implementation and
passes against the fix, and confirm to the best of my knowledge that the output does not include any
third-party copyrighted material and is compatible with the Apache License 2.0.