### PR TITLE
Add PDRadioButton.setNoToggleToOff and isNoToggleToOff methods

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/form/PDRadioButton.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/form/PDRadioButton.java
@@ -81,6 +81,29 @@ public final class PDRadioButton extends PDButton
     }
 
     /**
+     * From the PDF Spec <br>
+     * If set, exactly one radio button shall be selected at all times; clicking the currently
+     * selected button has no effect. If clear, clicking the selected button deselects it,
+     * leaving no button selected. This flag is meaningful only if the radio buttons are
+     * mutually exclusive, i.e. {@link #isRadiosInUnison()} is false.
+     *
+     * @param noToggleToOff The new flag for noToggleToOff.
+     */
+    public void setNoToggleToOff(boolean noToggleToOff)
+    {
+        getCOSObject().setFlag(COSName.FF, FLAG_NO_TOGGLE_TO_OFF, noToggleToOff);
+    }
+
+    /**
+     *
+     * @return true if the flag is set preventing a radio button from being toggled to off.
+     */
+    public boolean isNoToggleToOff()
+    {
+        return getCOSObject().getFlag(COSName.FF, FLAG_NO_TOGGLE_TO_OFF);
+    }
+
+    /**
      * This will get the selected index.
      * <p>
      * A RadioButton might have multiple same value options which are not selected jointly if

--- a/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/interactive/form/TestRadioButtons.java
+++ b/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/interactive/form/TestRadioButtons.java
@@ -137,6 +137,34 @@ class TestRadioButtons
     }
 
     /**
+     * Test getting/setting the NoToggleToOff flag (PDF spec Ff bit 15).
+     *
+     * @throws IOException If there is an error creating the field.
+     */
+    @Test
+    void testNoToggleToOff() throws IOException
+    {
+        try (PDDocument doc = new PDDocument())
+        {
+            PDAcroForm form = new PDAcroForm(doc);
+            PDRadioButton radioButton = new PDRadioButton(form);
+
+            // default shall be false/unset
+            assertFalse(radioButton.isNoToggleToOff());
+
+            radioButton.setNoToggleToOff(true);
+            assertTrue(radioButton.isNoToggleToOff());
+            // spec bit 15 -> mask 1 << 14
+            assertEquals(1 << 14,
+                    radioButton.getCOSObject().getInt(COSName.FF) & (1 << 14));
+
+            radioButton.setNoToggleToOff(false);
+            assertFalse(radioButton.isNoToggleToOff());
+            assertEquals(0, radioButton.getCOSObject().getInt(COSName.FF) & (1 << 14));
+        }
+    }
+
+    /**
      * PDFBOX-3656 Radio button field with FLAG_RADIOS_IN_UNISON false
      * 
      * @throws IOException


### PR DESCRIPTION
The PDRadioButton class has a private field named FLAG_NO_TOGGLE_TO_OFF. Therefore, there are three options: 1) remove it; 2) add methods to use it; 3) do nothing.