### PR TITLE
PDFBOX-4951: Set glyph layout processor for font

### DIFF
--- a/pdfbox-layout-awt/src/main/java/org/apache/pdfbox/glyphlayout/awt/GlyphLayoutFontLoaderAwt.java
+++ b/pdfbox-layout-awt/src/main/java/org/apache/pdfbox/glyphlayout/awt/GlyphLayoutFontLoaderAwt.java
@@ -42,18 +42,23 @@ import org.apache.pdfbox.pdmodel.font.PDType0Font;
  */
 public class GlyphLayoutFontLoaderAwt
 {
+    protected final GlyphLayoutProcessorAwt glyphLayoutProcessor;
 
     /**
      * Mapping from PDFBox font to AWT font
      */
     private final Map<PDType0Font, Font> awtFontMap = new ConcurrentHashMap<>();
 
+    public GlyphLayoutFontLoaderAwt(GlyphLayoutProcessorAwt glyphLayoutProcessor) {
+        this.glyphLayoutProcessor = glyphLayoutProcessor;
+    }
+
     /**
      * Loads the AWT font needed for layout
      *
      * @param pdDocument document
      * @param inputStream of the font
-     * @return pdType0Font PDFBox font
+     * @return PDType0Font PDFBox font
      * @throws IOException if font can not be loaded
      * @throws FontFormatException if the font is bad
      */
@@ -70,7 +75,7 @@ public class GlyphLayoutFontLoaderAwt
      * @param inputStream of the font
      * @param embedSubset True if the font will be subset before embedding. Set this to false when
      * creating a font for AcroForm.
-     * @return pdType0Font PDFBox font
+     * @return PDType0Font PDFBox font
      * @throws IOException if font can not be loaded
      * @throws FontFormatException if the font is bad
      */
@@ -86,7 +91,7 @@ public class GlyphLayoutFontLoaderAwt
      * @param pdDocument document
      * @param inputStream of the font
      * @param fontOptions options for font
-     * @return pdType0Font PDFBox font
+     * @return PDType0Font PDFBox font
      * @throws IOException if font can not be loaded
      * @throws FontFormatException if the font is bad
      */
@@ -104,7 +109,7 @@ public class GlyphLayoutFontLoaderAwt
      * @param embedSubset True if the font will be subset before embedding. Set this to false when
      * creating a font for AcroForm.
      * @param fontOptions Options for font
-     * @return pdType0Font PDFBox font
+     * @return PDType0Font PDFBox font
      * @throws IOException if font can not be loaded
      * @throws FontFormatException if the font is bad
      */
@@ -117,6 +122,7 @@ public class GlyphLayoutFontLoaderAwt
         try (ByteArrayInputStream bais = new ByteArrayInputStream(inputStream.readAllBytes()))
         {
             PDType0Font pdType0Font = PDType0Font.load(pdDocument, bais, embedSubset);
+            pdType0Font.setGlyphLayoutProcessor(glyphLayoutProcessor);
             bais.reset();
             loadAwtFont(pdType0Font, bais, fontOptions);
             return pdType0Font;
@@ -155,7 +161,8 @@ public class GlyphLayoutFontLoaderAwt
      */
     public boolean supportsFont(PDFont font)
     {
-        return awtFontMap.containsKey(font);
+        return (font instanceof PDType0Font)
+                && awtFontMap.containsKey((PDType0Font)font);
     }
 
     /**
@@ -164,7 +171,7 @@ public class GlyphLayoutFontLoaderAwt
      * @param font PDFBox font
      * @return AWT font if available
      */
-    public Font getAwtFont(PDType0Font font)
+    protected Font getAwtFont(PDType0Font font)
     {
         return awtFontMap.get(font);
     }

--- a/pdfbox-layout-awt/src/main/java/org/apache/pdfbox/glyphlayout/awt/GlyphLayoutProcessorAwt.java
+++ b/pdfbox-layout-awt/src/main/java/org/apache/pdfbox/glyphlayout/awt/GlyphLayoutProcessorAwt.java
@@ -47,7 +47,6 @@ import org.apache.pdfbox.pdmodel.font.PDType0Font;
  */
 public class GlyphLayoutProcessorAwt extends AbstractGlyphLayoutProcessor implements GlyphLayoutProcessorInterface
 {
-
     private final GlyphLayoutFontLoaderAwt glyphLayoutFontLoaderAwt;
 
     /**
@@ -56,7 +55,7 @@ public class GlyphLayoutProcessorAwt extends AbstractGlyphLayoutProcessor implem
      */
     public GlyphLayoutProcessorAwt()
     {
-        this.glyphLayoutFontLoaderAwt = new GlyphLayoutFontLoaderAwt();
+        this.glyphLayoutFontLoaderAwt = new GlyphLayoutFontLoaderAwt(this);
     }
 
     /**
@@ -210,6 +209,7 @@ public class GlyphLayoutProcessorAwt extends AbstractGlyphLayoutProcessor implem
         Rectangle2D rect = glyphVector.getLogicalBounds();
         return (float) rect.getWidth();
     }
+
 
     /**
      * Shows a text using glyph positioning (if needed) This text must have a uniform run direction.

--- a/pdfbox-layout-awt/src/test/java/org/apache/pdfbox/glyphlayout/awt/GlyphLayoutLigaturesAndKerningTest.java
+++ b/pdfbox-layout-awt/src/test/java/org/apache/pdfbox/glyphlayout/awt/GlyphLayoutLigaturesAndKerningTest.java
@@ -34,7 +34,7 @@ import org.apache.pdfbox.pdmodel.font.PDType0Font;
 /**
  * Examples for ligatures and kerning
  * See <a href="https://issues.apache.org/jira/browse/PDFBOX-4951">PDFBOX-4951</a>
- *
+ * <p>
  * The default processing of GlyphLayoutProcessor is with ligatures and kerning disabled.
  * You can enable ligatures and kerning using FontOptions, see below.
  *
@@ -52,8 +52,8 @@ class GlyphLayoutLigaturesAndKerningTest extends TestBase
     /**
      * Check that missing glyph is caught like in main pdfbox.
      *
-     * @throws IOException
-     * @throws FontFormatException
+     * @throws IOException if an I/O error occurs
+     * @throws FontFormatException if the font contains errors
      */
     @Test
     void testMissingGlyph() throws IOException, FontFormatException
@@ -151,6 +151,11 @@ class GlyphLayoutLigaturesAndKerningTest extends TestBase
                 float f2 = dejavuLigKernFont.getStringWidth(DEJAVU_STRING) * dejavuLigKernFont.getFontMatrix().getScaleX() * fontSize;
                 float f3 = glyphLayoutProcessor.getStringWidth(dejavuFont, fontSize, DEJAVU_STRING);
                 float f4 = glyphLayoutProcessor.getStringWidth(dejavuLigKernFont, fontSize, DEJAVU_STRING);
+
+                float f5 = glyphLayoutProcessor.getStringWidth(dejavuLigKernFont, fontSize, DEJAVU_STRING+" ");
+                float f6 = glyphLayoutProcessor.getStringWidth(dejavuLigKernFont, fontSize, DEJAVU_STRING);
+                System.out.printf("mit leerz %f ohne %f%n", f5, f6);
+
 
                 // equality is expected here, but this shows that the ordinary getStringWidth() isn't helpful
                 assertEquals(f1, f2);

--- a/pdfbox-layout-fop/src/main/java/org/apache/pdfbox/glyphlayout/fop/GlyphLayoutFontLoaderFop.java
+++ b/pdfbox-layout-fop/src/main/java/org/apache/pdfbox/glyphlayout/fop/GlyphLayoutFontLoaderFop.java
@@ -34,6 +34,7 @@ import org.apache.fop.fonts.FontLoader;
 import org.apache.fop.fonts.FontUris;
 import org.apache.fop.fonts.MultiByteFont;
 
+import org.apache.pdfbox.pdmodel.GlyphLayoutProcessorInterface;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.pdfbox.pdmodel.font.PDType0Font;
@@ -50,6 +51,7 @@ import org.apache.xmlgraphics.io.ResourceResolver;
  */
 public class GlyphLayoutFontLoaderFop
 {
+    private final GlyphLayoutProcessorInterface glyphLayoutProcessor;
 
     /**
      * Mapping from PDFBox font to AWT font
@@ -57,11 +59,20 @@ public class GlyphLayoutFontLoaderFop
     private final Map<PDType0Font, MultiByteFont> fopFontMap = new ConcurrentHashMap<>();
 
     /**
+     * Creates a GlyphLayoutFontLoaderFop
+     * @param glyphLayoutProcessor the corresponding glyph layout processor
+     */
+    public GlyphLayoutFontLoaderFop(GlyphLayoutProcessorInterface glyphLayoutProcessor) {
+        this.glyphLayoutProcessor = glyphLayoutProcessor;
+    }
+
+    /**
      * Loads the AWT font needed for layout
      *
      * @param pdDocument document
      * @param inputStream of the font
-     * @param embedSubset
+     * @param embedSubset True if the font will be subset before embedding. Set this to false when
+     *                    creating a font for AcroForm.
      * @return pdType0Font PDFBox font
      * @throws IOException if font can not be loaded
      */
@@ -75,6 +86,7 @@ public class GlyphLayoutFontLoaderFop
         try (ByteArrayInputStream bais = new ByteArrayInputStream(inputStream.readAllBytes()))
         {
             pdType0Font = PDType0Font.load(pdDocument, bais, embedSubset);
+            pdType0Font.setGlyphLayoutProcessor(glyphLayoutProcessor);
             bais.reset();
             loadFopFont(pdType0Font, bais);
         }
@@ -143,7 +155,7 @@ public class GlyphLayoutFontLoaderFop
      * @param font PDFBox font
      * @return fop font if available
      */
-    public MultiByteFont getFopFont(PDType0Font font)
+    protected MultiByteFont getFopFont(PDType0Font font)
     {
         return fopFontMap.get(font);
     }
@@ -151,7 +163,7 @@ public class GlyphLayoutFontLoaderFop
     /**
      * Resolver needed to construct a FOP MultibyteFont
      */
-    static class FopInputStreamResourceResolver implements ResourceResolver
+    protected static class FopInputStreamResourceResolver implements ResourceResolver
     {
         private final InputStream inputStream;
 

--- a/pdfbox-layout-fop/src/main/java/org/apache/pdfbox/glyphlayout/fop/GlyphLayoutProcessorFop.java
+++ b/pdfbox-layout-fop/src/main/java/org/apache/pdfbox/glyphlayout/fop/GlyphLayoutProcessorFop.java
@@ -60,7 +60,7 @@ public class GlyphLayoutProcessorFop extends AbstractGlyphLayoutProcessor implem
      */
     public GlyphLayoutProcessorFop()
     {
-        this.glyphLayoutFontLoaderFop = new GlyphLayoutFontLoaderFop();
+        this.glyphLayoutFontLoaderFop = new GlyphLayoutFontLoaderFop(this);
     }
 
     /**
@@ -99,6 +99,7 @@ public class GlyphLayoutProcessorFop extends AbstractGlyphLayoutProcessor implem
     {
         return glyphLayoutFontLoaderFop.supportsFont(font);
     }
+
 
     /**
      * Loads the font needed for layout
@@ -139,7 +140,7 @@ public class GlyphLayoutProcessorFop extends AbstractGlyphLayoutProcessor implem
     {
         TextAndGpa textAndGpa = computeGlyphsAndPositions(font, fontSize, text, bidiLevel);
         // PDType0Font.getStringWidth returns glyph widths in 1000-units. Convert to user space using font matrix and fontSize
-        float raw = font.getStringWidth(textAndGpa.getText());
+        float raw = font.getStringWidthBasic(textAndGpa.getText());
         float scaleX = font.getFontMatrix().getScaleX();
         return raw * scaleX * fontSize;
     }

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/AbstractGlyphLayoutProcessor.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/AbstractGlyphLayoutProcessor.java
@@ -76,9 +76,14 @@ public abstract class AbstractGlyphLayoutProcessor implements GlyphLayoutProcess
      * @param fontSize font size
      * @param text text
      * @return string width
+     * @throws IllegalArgumentException if the font is not supported or glyphs are missing
      */
     public float getStringWidth(PDType0Font font, float fontSize, String text) throws IOException
     {
+        if (!supportsFont(font))
+        {
+            throw new IllegalArgumentException("font must be supported by the GlyphLayoutProcessor");
+        }
         float width = 0f;
         List<TextAndBidiLevel> textAndBidiLevels = doBidiSplittingAndReordering(text);
         for (TextAndBidiLevel textAndBidiLevel:  textAndBidiLevels)
@@ -112,11 +117,15 @@ public abstract class AbstractGlyphLayoutProcessor implements GlyphLayoutProcess
      * @param text text to show
      *
      * @throws IOException if an I/O exception occurs
-     * @throws IllegalArgumentException if glyphs are missing
+     * @throws IllegalArgumentException if the font is not supported or glyphs are missing
      */
     public void showText(ContentStreamForGlyphLayoutInterface contentStream, PDType0Font font, float fontSize, String text)
             throws IOException
     {
+        if (!supportsFont(font))
+        {
+            throw new IllegalArgumentException("font must be supported by the GlyphLayoutProcessor");
+        }
         List<TextAndBidiLevel> textAndBidiLevels = doBidiSplittingAndReordering(text);
         for (TextAndBidiLevel textAndBidiLevel:  textAndBidiLevels)
         {

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDAbstractContentStream.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDAbstractContentStream.java
@@ -353,10 +353,20 @@ abstract class PDAbstractContentStream implements ContentStreamForGlyphLayoutInt
         }
         else
         {
-            showTextInternal(text);
-            writeBytes(ASCII_SPACE);
-            writeOperator(OperatorName.SHOW_TEXT);
+            showTextBasic(text);
         }
+    }
+
+    /**
+     * Shows the text
+     *
+     * @param text text to be shown
+     * @throws IOException if an I/O exception occurs
+     */
+    protected void showTextBasic(String text) throws IOException {
+        showTextInternal(text);
+        writeBytes(ASCII_SPACE);
+        writeOperator(OperatorName.SHOW_TEXT);
     }
 
     /**

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/PDType0Font.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/PDType0Font.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.logging.log4j.Logger;
@@ -40,6 +41,7 @@ import org.apache.pdfbox.cos.COSObject;
 import org.apache.pdfbox.io.RandomAccessRead;
 import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.io.RandomAccessReadBufferedFile;
+import org.apache.pdfbox.pdmodel.GlyphLayoutProcessorInterface;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.ResourceCache;
 import org.apache.pdfbox.util.Matrix;
@@ -64,6 +66,8 @@ public class PDType0Font extends PDFont implements PDVectorFont
     private boolean isDescendantCJK;
     private PDCIDFontType2Embedder embedder;
     private TrueTypeFont ttf;
+    private GlyphLayoutProcessorInterface glyphLayoutProcessor;
+
 
     /**
      * Constructor for reading a Type0 font from a PDF file.
@@ -755,4 +759,41 @@ public class PDType0Font extends PDFont implements PDVectorFont
         return cmapLookup;
     }
 
+    /**
+     *
+     * @param glyphLayoutProcessor
+     */
+    public void setGlyphLayoutProcessor(GlyphLayoutProcessorInterface glyphLayoutProcessor) {
+        Objects.requireNonNull(glyphLayoutProcessor, "glyphLayoutProcessor must be not null");
+        this.glyphLayoutProcessor = glyphLayoutProcessor;
+    }
+
+    /**
+     * Returns the width of the given Unicode string.
+     * If a glyph layout processor is set, it is used to compute the string width
+     *
+     * @param text The text to get the width of.
+     * @return The width of the string in 1/1000 units of text space.
+     * @throws IOException If there is an error getting the width information.
+     * @throws IllegalArgumentException if a character isn't supported by the font.
+     */
+    @Override
+    public float getStringWidth(String text) throws IOException
+    {
+        return glyphLayoutProcessor != null && glyphLayoutProcessor.supportsFont(this)
+                ?   glyphLayoutProcessor.getStringWidth((PDType0Font) this, 1.0f, text) / getFontMatrix().getScaleX()
+                :   getStringWidthBasic(text);
+    }
+    /**
+     * Returns the width of the given Unicode string.
+     *
+     * @param text The text to get the width of.
+     * @return The width of the string in 1/1000 units of text space.
+     * @throws IOException If there is an error getting the width information.
+     * @throws IllegalArgumentException if a character isn't supported by the font.
+     */
+    public float getStringWidthBasic(String text) throws IOException
+    {
+        return super.getStringWidth(text);
+    }
 }

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/AppearanceStyle.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/AppearanceStyle.java
@@ -16,6 +16,7 @@
  */
 package org.apache.pdfbox.pdmodel.interactive;
 
+import org.apache.pdfbox.pdmodel.GlyphLayoutProcessorInterface;
 import org.apache.pdfbox.pdmodel.font.PDFont;
 
 /**
@@ -38,7 +39,12 @@ public class AppearanceStyle
      * Defaulting to 1.2*fontSize to match Acrobats default.
      */
     private float leading = 14.4f;
-    
+
+    /**
+     * Glyph layout processor
+     */
+    private GlyphLayoutProcessorInterface glyphLayoutProcessor;
+
     /**
      * Get the font used for text formatting.
      * 
@@ -99,4 +105,5 @@ public class AppearanceStyle
     {
         this.leading = leading;
     }
+
 }

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/PlainText.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/PlainText.java
@@ -32,21 +32,21 @@ import org.apache.pdfbox.pdmodel.font.PDFont;
  * A block of text can contain multiple paragraphs which will
  * be treated individually within the block placement.
  * </p>
- * 
+ *
  */
 public class PlainText
 {
     private static final float FONTSCALE = 1000f;
-    
+
     private final List<Paragraph> paragraphs;
-    
+
     /**
      * Construct the text block from a single value.
-     * 
+     * <p>
      * Constructs the text block from a single value splitting
-     * into individual {@link Paragraph} when a new line character is 
+     * into individual {@link Paragraph} when a new line character is
      * encountered.
-     * 
+     *
      * @param textValue the text block string.
      */
     public PlainText(String textValue)
@@ -71,13 +71,13 @@ public class PlainText
             }
         }
     }
-    
+
     /**
      * Construct the text block from a list of values.
-     * 
+     * <p>
      * Constructs the text block from a list of values treating each
      * entry as an individual {@link Paragraph}.
-     * 
+     *
      * @param listValue the text block string.
      */
     public PlainText(List<String> listValue)
@@ -85,20 +85,20 @@ public class PlainText
         paragraphs = new ArrayList<>(listValue.size());
         listValue.forEach(part -> paragraphs.add(new Paragraph(part)));
     }
-    
+
     /**
      * Get the list of paragraphs.
-     * 
+     *
      * @return the paragraphs.
      */
     public List<Paragraph> getParagraphs()
     {
         return paragraphs;
     }
-    
+
     /**
      * Attribute keys and attribute values used for text handling.
-     * 
+     * <p>
      * This is similar to {@link java.awt.font.TextAttribute} but
      * handled individually as to avoid a dependency on awt.
      */
@@ -113,12 +113,12 @@ public class PlainText
          * Attribute width of the text.
          */
         public static final Attribute WIDTH = new TextAttribute("width");
-        
+
         protected TextAttribute(String name)
         {
             super(name);
         }
-        
+
 
     }
 
@@ -207,15 +207,15 @@ public class PlainText
                     wordNeedsSplit = true;
 
                     // PDFBOX-5049:  The original approach was to decrement splitOffset
-                    // until the substring fits, but this can be very expensive for long words and 
+                    // until the substring fits, but this can be very expensive for long words and
                     // narrow widths (e.g. a long URL in a narrow column).
-                    // 
+                    //
                     // Optimization: instead of decrementing splitOffset one step at a time and
                     // calling getStringWidth on progressively shorter substrings:
                     //   - compute the scaled width of every individual character once
                     //   - build a prefix-sum array
                     //   - binary-search for the largest prefix that fits
-                    // 
+                    //
                     // TODO: The special case in PDFBOX-5049 should be handled by not generating an appearance
                     // stream at all as the the height of the text box is only 1pt and the text is not visible.
 
@@ -315,7 +315,7 @@ public class PlainText
             return lo;
         }
     }
-    
+
     /**
      * An individual line of text.
      */
@@ -328,12 +328,12 @@ public class PlainText
         {
             return lineWidth;
         }
-        
+
         void setWidth(float width)
         {
             lineWidth = width;
         }
-        
+
         float calculateWidth(PDFont font, float fontSize) throws IOException
         {
             final float scale = fontSize/FONTSCALE;
@@ -341,7 +341,7 @@ public class PlainText
             int indexOfWord = 0;
             for (Word word : words)
             {
-                calculatedWidth = calculatedWidth + 
+                calculatedWidth = calculatedWidth +
                         (Float) word.getAttributes().getIterator().getAttribute(TextAttribute.WIDTH);
                 String text = word.getText();
                 if (indexOfWord == words.size() -1 && Character.isWhitespace(text.charAt(text.length()-1)))
@@ -358,7 +358,7 @@ public class PlainText
         {
             return words;
         }
-        
+
         float getInterWordSpacing(float width)
         {
             return (width - lineWidth)/(words.size()-1);
@@ -369,10 +369,10 @@ public class PlainText
             words.add(word);
         }
     }
-    
+
     /**
      * An individual word.
-     * 
+     * <p>
      * A word is defined as a string which must be kept
      * on the same line.
      */
@@ -380,22 +380,22 @@ public class PlainText
     {
         private AttributedString attributedString;
         private final String textContent;
-        
+
         Word(String text)
         {
             textContent = text;
         }
-        
+
         String getText()
         {
             return textContent;
         }
-        
+
         AttributedString getAttributes()
         {
             return attributedString;
         }
-        
+
         void setAttributes(AttributedString as)
         {
             this.attributedString = as;

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/PlainTextFormatter.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/PlainTextFormatter.java
@@ -27,7 +27,7 @@ import org.apache.pdfbox.pdmodel.interactive.PlainText.Word;
 
 /**
  * TextFormatter to handle plain text formatting for annotation rectangles.
- * 
+ * <p>
  * The text formatter will take a single value or an array of values which
  * are treated as paragraphs.
  */
@@ -39,18 +39,18 @@ public class PlainTextFormatter
      * The scaling factor for font units to PDF units
      */
     private static final int FONTSCALE = 1000;
-    
+
     private final AppearanceStyle appearanceStyle;
     private final boolean wrapLines;
     private final float width;
-    
+
     private final PDAppearanceContentStream contents;
     private final PlainText textContent;
     private final TextAlign textAlignment;
-    
+
     private float horizontalOffset;
     private float verticalOffset;
-    
+
     public static class Builder
     {
 
@@ -63,12 +63,12 @@ public class PlainTextFormatter
         private float width = 0f;
         private PlainText textContent;
         private TextAlign textAlignment = TextAlign.LEFT;
-        
-       
+
+
         // initial offset from where to start the position of the first line
         private float horizontalOffset = 0f;
         private float verticalOffset = 0f;
-        
+
         public Builder(PDAppearanceContentStream contents)
         {
             this.contents = contents;
@@ -79,7 +79,7 @@ public class PlainTextFormatter
             this.appearanceStyle = appearanceStyle;
             return this;
         }
-        
+
         public Builder wrapLines(boolean wrapLines)
         {
             this.wrapLines = wrapLines;
@@ -97,33 +97,33 @@ public class PlainTextFormatter
             this.textAlignment  = TextAlign.valueOf(alignment);
             return this;
         }
-        
+
         public Builder textAlign(TextAlign alignment)
         {
             this.textAlignment  = alignment;
             return this;
         }
-        
-        
+
+
         public Builder text(PlainText textContent)
         {
             this.textContent  = textContent;
             return this;
         }
-        
+
         public Builder initialOffset(float horizontalOffset, float verticalOffset)
         {
             this.horizontalOffset = horizontalOffset;
             this.verticalOffset = verticalOffset;
             return this;
         }
-        
+
         public PlainTextFormatter build()
         {
             return new PlainTextFormatter(this);
         }
     }
-    
+
     private PlainTextFormatter(Builder builder)
     {
         appearanceStyle = builder.appearanceStyle;
@@ -135,10 +135,10 @@ public class PlainTextFormatter
         horizontalOffset = builder.horizontalOffset;
         verticalOffset = builder.verticalOffset;
     }
-    
+
     /**
      * Format the text block.
-     * 
+     *
      * @throws IOException if there is an error writing to the stream.
      */
     public void format() throws IOException
@@ -151,37 +151,37 @@ public class PlainTextFormatter
                 if (wrapLines)
                 {
                     List<Line> lines = paragraph.getLines(
-                                appearanceStyle.getFont(), 
-                                appearanceStyle.getFontSize(), 
-                                width
-                            );
+                            appearanceStyle.getFont(),
+                            appearanceStyle.getFontSize(),
+                            width
+                    );
                     processLines(lines, isFirstParagraph);
                     isFirstParagraph = false;
                 }
                 else
                 {
                     float startOffset = 0f;
-                    
-                    
+
+
                     float lineWidth = appearanceStyle.getFont().getStringWidth(paragraph.getText()) *
                             appearanceStyle.getFontSize() / FONTSCALE;
-                    
-                    if (lineWidth < width) 
+
+                    if (lineWidth < width)
                     {
                         switch (textAlignment)
                         {
-                        case CENTER:
-                            startOffset = (width - lineWidth)/2;
-                            break;
-                        case RIGHT:
-                            startOffset = width - lineWidth;
-                            break;
-                        case JUSTIFY:
-                        default:
-                            startOffset = 0f;
+                            case CENTER:
+                                startOffset = (width - lineWidth)/2;
+                                break;
+                            case RIGHT:
+                                startOffset = width - lineWidth;
+                                break;
+                            case JUSTIFY:
+                            default:
+                                startOffset = 0f;
                         }
                     }
-                    
+
                     contents.newLineAtOffset(horizontalOffset + startOffset, verticalOffset);
                     contents.showText(paragraph.getText());
                 }
@@ -191,10 +191,10 @@ public class PlainTextFormatter
 
     /**
      * Process lines for output. 
-     *
+     * <p>
      * Process lines for an individual paragraph and generate the 
      * commands for the content stream to show the text.
-     * 
+     *
      * @param lines the lines to process.
      * @throws IOException if there is an error writing to the stream.
      */
@@ -205,29 +205,29 @@ public class PlainTextFormatter
         float lastPos = 0f;
         float startOffset = 0f;
         float interWordSpacing = 0f;
-        
+
         for (Line line : lines)
         {
             switch (textAlignment)
             {
-            case CENTER:
-                startOffset = (width - line.getWidth())/2;
-                break;
-            case RIGHT:
-                startOffset = width - line.getWidth();
-                break;
-            case JUSTIFY:
-                if (lines.indexOf(line) != lines.size() -1)
-                {
-                    interWordSpacing = line.getInterWordSpacing(width);
-                }
-                break;
-            default:
-                startOffset = 0f;
+                case CENTER:
+                    startOffset = (width - line.getWidth())/2;
+                    break;
+                case RIGHT:
+                    startOffset = width - line.getWidth();
+                    break;
+                case JUSTIFY:
+                    if (lines.indexOf(line) != lines.size() -1)
+                    {
+                        interWordSpacing = line.getInterWordSpacing(width);
+                    }
+                    break;
+                default:
+                    startOffset = 0f;
             }
-            
+
             float offset = -lastPos + startOffset + horizontalOffset;
-            
+
             if (lines.indexOf(line) == 0 && isFirstParagraph)
             {
                 contents.newLineAtOffset(offset, verticalOffset);
@@ -239,7 +239,7 @@ public class PlainTextFormatter
                 contents.newLineAtOffset(offset, - appearanceStyle.getLeading());
             }
 
-            lastPos += offset; 
+            lastPos += offset;
 
             List<Word> words = line.getWords();
             int wordIndex = 0;

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/form/AppearanceGeneratorHelper.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/interactive/form/AppearanceGeneratorHelper.java
@@ -39,6 +39,7 @@ import org.apache.pdfbox.pdmodel.PDResources;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.pdfbox.pdmodel.font.PDSimpleFont;
+import org.apache.pdfbox.pdmodel.font.PDType0Font;
 import org.apache.pdfbox.pdmodel.font.PDType3CharProc;
 import org.apache.pdfbox.pdmodel.font.PDType3Font;
 import org.apache.pdfbox.pdmodel.font.PDVectorFont;
@@ -531,6 +532,9 @@ class AppearanceGeneratorHelper
             
             // get the font
             PDFont font = defaultAppearance.getFont();
+            if (glyphLayoutProcessor != null && glyphLayoutProcessor.supportsFont(font)) {
+                ((PDType0Font)font).setGlyphLayoutProcessor(glyphLayoutProcessor);
+            }
             if (font == null)
             {
                 throw new IllegalArgumentException("font is null, check whether /DA entry is incomplete or incorrect");
@@ -637,7 +641,7 @@ class AppearanceGeneratorHelper
                 AppearanceStyle appearanceStyle = new AppearanceStyle();
                 appearanceStyle.setFont(font);
                 appearanceStyle.setFontSize(fontSize);
-                
+
                 // Adobe Acrobat uses the font's bounding box for the leading between the lines
                 appearanceStyle.setLeading(font.getBoundingBox().getHeight() * fontScaleY);
                 
@@ -938,7 +942,7 @@ class AppearanceGeneratorHelper
                         {
                             return Math.max(fs - 1, MINIMUM_FONT_SIZE);
                         }
-                        fs += 1.0;
+                        fs += 1.0f;
                     }
                     return Math.min(fs, DEFAULT_FONT_SIZE);
                 }


### PR DESCRIPTION
Set glyph layout processor for font for correct computing of stringWidth
See https://issues.apache.org/jira/browse/PDFBOX-4951