### PR TITLE
optimize JPEGFactory methods

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/JPEGFactory.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/JPEGFactory.java
@@ -81,7 +81,7 @@ public final class JPEGFactory
     public static PDImageXObject createFromStream(PDDocument document, InputStream stream)
             throws IOException
     {
-        if (!(stream instanceof ByteArrayInputStream) && !(stream instanceof BufferedInputStream))
+        if (!stream.markSupported())
         {
             stream = new BufferedInputStream(stream);
         }

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/JPEGFactory.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/JPEGFactory.java
@@ -25,6 +25,7 @@ import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.BufferedInputStream;
 import java.io.InputStream;
 import java.io.IOException;
 import java.util.Iterator;
@@ -80,25 +81,13 @@ public final class JPEGFactory
     public static PDImageXObject createFromStream(PDDocument document, InputStream stream)
             throws IOException
     {
-        return createFromByteArray(document, stream.readAllBytes());
-    }
+        if (!(stream instanceof ByteArrayInputStream) && !(stream instanceof BufferedInputStream))
+        {
+            stream = new BufferedInputStream(stream);
+        }
+        stream.mark(Integer.MAX_VALUE);
 
-    /**
-     * Creates a new JPEG Image XObject from a byte array containing JPEG data.
-     *
-     * @param document the document where the image will be created
-     * @param byteArray bytes of JPEG image
-     * @return a new Image XObject
-     *
-     * @throws IOException if the input stream cannot be read
-     */
-    public static PDImageXObject createFromByteArray(PDDocument document, byte[] byteArray)
-            throws IOException
-    {
-        // copy stream
-        ByteArrayInputStream byteStream = new ByteArrayInputStream(byteArray);
-
-        Dimensions meta = retrieveDimensions(byteStream);
+        Dimensions meta = retrieveDimensions(stream);
 
         PDColorSpace colorSpace;
         switch (meta.numComponents)
@@ -118,7 +107,7 @@ public final class JPEGFactory
         }
 
         // create PDImageXObject from stream
-        PDImageXObject pdImage = new PDImageXObject(document, byteStream, 
+        PDImageXObject pdImage = new PDImageXObject(document, stream,
                 COSName.DCT_DECODE, meta.width, meta.height, 8, colorSpace);
 
         if (colorSpace instanceof PDDeviceCMYK)
@@ -138,6 +127,21 @@ public final class JPEGFactory
         return pdImage;
     }
 
+    /**
+     * Creates a new JPEG Image XObject from a byte array containing JPEG data.
+     *
+     * @param document the document where the image will be created
+     * @param byteArray bytes of JPEG image
+     * @return a new Image XObject
+     *
+     * @throws IOException if the input stream cannot be read
+     */
+    public static PDImageXObject createFromByteArray(PDDocument document, byte[] byteArray)
+            throws IOException
+    {
+        return createFromStream(document, new ByteArrayInputStream(byteArray));
+    }
+
     private static class Dimensions
     {
         private int width;
@@ -145,7 +149,7 @@ public final class JPEGFactory
         private int numComponents;
     }
 
-    private static Dimensions retrieveDimensions(ByteArrayInputStream stream) throws IOException
+    private static Dimensions retrieveDimensions(InputStream stream) throws IOException
     {
         ImageReader reader =
                 Filter.findRasterReader("JPEG", "a suitable JAI I/O image filter is not installed");


### PR DESCRIPTION
The current version of the JPEGFactory.createFromByteArray method always creates a ByteArrayInputStream instance to read the image dimensions, and then creates a PDImageXObject instance. If we use the JPEGFactory.createFromStream method, we have a stream instance and create a new array. This is inefficient. We can work with streams and avoid duplicating memory (the InputStream from createFromStream can also be a ByteArrayInputStream).
I thought the InputStream.markSupported method should be used, and I found this information. The BufferedInputStream.reset() method can throw an exception only in a pathological extreme case: if, after mark(), more bytes were read than fit in the Java array (~2 GB). This isn't a drawback specific to BufferedInputStream—it's a fundamental limitation on storing arbitrary, rewindable data in memory, and it affects all approaches, including the original code before the refactoring (stream.readAllBytes()), which also resulted in an error (out of memory or exceeding array size limits) when handling multi-gigabyte input data. Therefore, BufferedInputStream is no worse than the alternative—it's just as good for realistic input data, with the same theoretical limit as everything else.
If this isn't acceptable, I can rewrite it using the markSupported method.
An additional benefit: the PDImageXObject.createFromFileByContent method now uses BufferedInputStream via the JPEGFactory.createFromStream method.