### PR TITLE
fix swapped error messages in CCITTFactory.extractFromTiff method

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/CCITTFactory.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/CCITTFactory.java
@@ -403,11 +403,11 @@ public final class CCITTFactory
                     // http://www.awaresystems.be/imaging/tiff/tifftags/t4options.html
                     if ((val & 4) != 0)
                     {
-                        throw new IOException("CCITT Group 3 'uncompressed mode' is not supported");
+                        throw new IOException("CCITT Group 3 'fill bits before EOL' is not supported");
                     }
                     if ((val & 2) != 0)
                     {
-                        throw new IOException("CCITT Group 3 'fill bits before EOL' is not supported");
+                        throw new IOException("CCITT Group 3 'uncompressed mode' is not supported");
                     }
                     break;
                 }


### PR DESCRIPTION
See: TIFFExtension.GROUP3OPT_UNCOMPRESSED and TIFFExtension.GROUP3OPT_FILLBITS.
I would prefer to use these constants there.