### PR TITLE
fix tiff parsing in CCITTFactory.extractFromTiff method

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/CCITTFactory.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/CCITTFactory.java
@@ -409,6 +409,12 @@ public final class CCITTFactory
                     {
                         throw new IOException("CCITT Group 3 'fill bits before EOL' is not supported");
                     }
+                    if ((val & 8) != 0)
+                    {
+                        // rows are byte-aligned; the copied compressed stream keeps that
+                        // alignment, so the PDF decoder must be told about it too
+                        params.setBoolean(COSName.ENCODED_BYTE_ALIGN, true);
+                    }
                     break;
                 }
                 case 324:


### PR DESCRIPTION
GROUP3OPT_BYTEALIGNED (bit 3, value 8) is silently ignored.
The tag-292 block never checks val & 8. But COSName.ENCODED_BYTE_ALIGN ("EncodedByteAlign") is a real, wired-up PDF DecodeParms key — CCITTFaxFilter.java:61 reads it (default false) and passes it straight to CCITTFaxDecoderStream. Since extractFromTiff copies the compressed bytes through unmodified, if the source TIFF was Group-3-encoded with byte-aligned rows, the resulting PDF needs /EncodedByteAlign true in its DecodeParms to decode correctly. Currently that flag is never set, so any such TIFF would produce a PDF image that decodes with progressively misaligned rows (visually corrupted/garbled output).
