### PR TITLE
refactor PDType1FontEmbedder constructor

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/PDType1FontEmbedder.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/PDType1FontEmbedder.java
@@ -59,10 +59,9 @@ class PDType1FontEmbedder
         dict.setItem(COSName.SUBTYPE, COSName.TYPE1);
 
         // read the pfb
-        byte[] pfbBytes = pfbStream.readAllBytes();
-        PfbParser pfbParser = new PfbParser(pfbBytes);
-        type1 = Type1Font.createWithPFB(pfbBytes);
-        
+        PfbParser pfbParser = new PfbParser(pfbStream);
+        type1 = Type1Font.createWithSegments(pfbParser.getSegment1(), pfbParser.getSegment2());
+
         if (encoding == null)
         {
             fontEncoding = Type1Encoding.fromFontBox(type1.getEncoding());


### PR DESCRIPTION
An instance of PfbParser will be created within the Type1Font.createWithPFB method. Therefore, in the current code, we have two instances of this type. Additionally, we can avoid usage of the PfbStream.readAllBytes method.