### PR TITLE
refactor GlyphLayoutFontLoaderAwt.loadFont method

### DIFF
--- a/pdfbox-layout-awt/src/main/java/org/apache/pdfbox/glyphlayout/awt/GlyphLayoutFontLoaderAwt.java
+++ b/pdfbox-layout-awt/src/main/java/org/apache/pdfbox/glyphlayout/awt/GlyphLayoutFontLoaderAwt.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.pdfbox.pdmodel.font.PDType0Font;
@@ -113,14 +114,14 @@ public class GlyphLayoutFontLoaderAwt
     {
         Objects.requireNonNull(inputStream, "InputStream must not be null");
 
-        // Copy font stream into memory to read it twice for creation of PDType0Font and AWT Font
-        try (ByteArrayInputStream bais = new ByteArrayInputStream(inputStream.readAllBytes()))
+        byte[] fontBytes = inputStream.readAllBytes();
+        PDType0Font pdType0Font = PDType0Font.load(pdDocument,
+                new RandomAccessReadBuffer(fontBytes), embedSubset, false);
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(fontBytes))
         {
-            PDType0Font pdType0Font = PDType0Font.load(pdDocument, bais, embedSubset);
-            bais.reset();
             loadAwtFont(pdType0Font, bais, fontOptions);
-            return pdType0Font;
         }
+        return pdType0Font;
     }
 
     /**


### PR DESCRIPTION
We create the byte array twice: in the GlyphLayoutFontLoaderAwt.loadFont method and inside the PDType0Font.load method (RandomAccessReadBuffer(InputStream)). I found a way to avoid double allocation.