### PR TITLE
refactor the FlateFilterDecoderStream.mark and reset methods

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/filter/FlateFilterDecoderStream.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/filter/FlateFilterDecoderStream.java
@@ -227,7 +227,7 @@ public final class FlateFilterDecoderStream extends FilterInputStream
      * @param readlimit ignored.
      */
     @Override
-    public synchronized void mark(int readlimit)
+    public void mark(int readlimit)
     {
     }
 
@@ -237,7 +237,7 @@ public final class FlateFilterDecoderStream extends FilterInputStream
      * @throws IOException always throw as reset is an unsupported feature.
      */
     @Override
-    public synchronized void reset() throws IOException
+    public void reset() throws IOException
     {
         throw new IOException("reset is not supported");
     }


### PR DESCRIPTION
The FlateFilterDecoderStream.mark and reset methods may be not synchronized because they do not use any fields or methods.