### PR TITLE
add the TestQuality.testPDFBox6232

### DIFF
--- a/pdfbox/pom.xml
+++ b/pdfbox/pom.xml
@@ -1033,6 +1033,19 @@
                             <sha512>0d7160a4af04bf2f785bf4155f69876da4b7ff7a196e7eda1eb904c02c35aa03c31041d9339fda90322cb58bde16b87bae8460c617bfe5b8dc0670ddab102f62</sha512>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>PDFBOX-6232</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>https://issues.apache.org/jira/secure/attachment/13083774/pdfbox_softmask_regression_ipfree.pdf</url>
+                            <outputDirectory>${project.build.directory}/pdfs</outputDirectory>
+                            <outputFileName>PDFBOX-6232-softmask-in-tiling-pattern-in-isolated-group.pdf</outputFileName>
+                            <sha512>83921c4d53e482afb31bff310850a2d05b689e7d9b6ef03891b700b14d1c6015e728763731f633f79356c4358b9d3717ef4a7428cce6530f5df3bd8e0cb9978c</sha512>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/pdfbox/src/test/java/org/apache/pdfbox/rendering/TestQuality.java
+++ b/pdfbox/src/test/java/org/apache/pdfbox/rendering/TestQuality.java
@@ -126,4 +126,33 @@ class TestQuality
                     "expected a dark text pixel but was too light: " + Integer.toHexString(rgb));
         }
     }
+
+    /**
+     * PDFBOX-6232: a luminosity soft mask (driven by a shading-pattern gradient) applied inside a
+     * tiling pattern that is itself used within an isolated transparency group must be positioned
+     * using the enclosing group's coordinate system, not the tiling pattern's own tile raster.
+     * Before the fix, the mask was sampled at the wrong offset, so the pattern's gradient collapsed
+     * towards the backdrop color instead of showing its full-strength color partway down the
+     * gradient.
+     *
+     * @throws IOException
+     */
+    @Test
+    void testPDFBox6232() throws IOException
+    {
+        File file = new File(TARGET_PDF_DIR, "PDFBOX-6232-softmask-in-tiling-pattern-in-isolated-group.pdf");
+        try (PDDocument doc = Loader.loadPDF(file))
+        {
+            PDFRenderer renderer = new PDFRenderer(doc);
+            BufferedImage renderedImage = renderer.renderImageWithDPI(0, 100);
+            // a pixel partway down the gradient, which must be a saturated blue; before the fix,
+            // the broken mask offset made it collapse towards the dark backdrop colour instead
+            // (blue channel ~80 instead of ~220, as reported in the JIRA issue)
+            int rgb = renderedImage.getRGB(413, 294);
+            int blue = rgb & 0xFF;
+            Assertions.assertTrue(blue > 150,
+                    "expected a saturated blue gradient pixel but was too dark: " +
+                    Integer.toHexString(rgb));
+        }
+    }
 }


### PR DESCRIPTION
- Added testPDFBox6232() to TestQuality.java — confirmed it fails on the original code (blue channel 0x52=82, matching the ticket's exact "~80" figure) and passes with the fix.
- Added the reproducer PDF to the rendering smoke-test resources; the full TestRendering suite (11 files) passes.
-------------------------------------------------------
- Per https://www.apache.org/legal/generative-tooling.html: portions of this PR were
produced with assistance from Claude Code (Anthropic), based on a bug was described in Apache PDFBOX Issue Tracker.

I've reviewed the generated code and confirm to the best of my knowledge that the output does not include any
third-party copyrighted material and is compatible with the Apache License 2.0.