### PR TITLE
add the PDFontTest.testPDFBox5960 method and test file

### DIFF
--- a/pdfbox/pom.xml
+++ b/pdfbox/pom.xml
@@ -1033,6 +1033,19 @@
                             <sha512>0d7160a4af04bf2f785bf4155f69876da4b7ff7a196e7eda1eb904c02c35aa03c31041d9339fda90322cb58bde16b87bae8460c617bfe5b8dc0670ddab102f62</sha512>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>PDFBOX-5960</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>https://issues.apache.org/jira/secure/attachment/13074906/PDFJS-19527-reduced1.pdf</url>
+                            <outputDirectory>${project.build.directory}/pdfs</outputDirectory>
+                            <outputFileName>PDFBOX-5960-reduced1.pdf</outputFileName>
+                            <sha512>cd6d92c643108cdcf2b4c6a4ae4cc5a15d848e3335f6c8a135a5438d691eb982d11cfd8f26d11839321e06a364126d9b0c9732b4a19785821b844fe0ec94d525</sha512>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/font/PDFontTest.java
+++ b/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/font/PDFontTest.java
@@ -548,4 +548,28 @@ class PDFontTest
             assertEquals("CID and GID not identical: CID 628 != GID 372, use a ttf font instead", t.getMessage());
         }
     }
+
+    /**
+     * PDFBOX-5960: a TrueType font whose FontDescriptor has both the Symbolic and NonSymbolic
+     * flags set (self-contradictory) but which has an Encoding dictionary with a recognized
+     * /BaseEncoding and /Differences must resolve glyphs by name rather than through the
+     * code-based symbolic cmap, which yields the wrong glyph here.
+     *
+     * @throws IOException
+     */
+    @Test
+    void testPDFBox5960() throws IOException
+    {
+        try (PDDocument doc = Loader.loadPDF(new File("target/pdfs", "PDFBOX-5960-reduced1.pdf")))
+        {
+            PDPage page = doc.getPage(0);
+            PDFont font = page.getResources().getFont(COSName.getPDFName("F1"));
+            assertTrue(font instanceof PDTrueTypeFont);
+            PDTrueTypeFont ttf = (PDTrueTypeFont) font;
+            // code 71 ('G' in the content stream) is mapped by /Differences to "Ccedilla",
+            // which must be resolved by name (GID 90, the diameter symbol in this font),
+            // not through the symbolic code-based cmap (which wrongly yields GID 34, "G").
+            assertEquals(90, ttf.codeToGID(71));
+        }
+    }
 }


### PR DESCRIPTION
Per https://www.apache.org/legal/generative-tooling.html: portions of this PR were
produced with assistance from Claude Code (Anthropic), based on a bug was described in Apache PDFBOX Issue Tracker.

I've reviewed the generated code and confirm to the best of my knowledge that the output does not include any
third-party copyrighted material and is compatible with the Apache License 2.0.