### PR TITLE
fix diameter symbol missing [PDFBOX-5960]

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/PDTrueTypeFont.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/PDTrueTypeFont.java
@@ -51,6 +51,7 @@ import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.common.PDStream;
 import org.apache.pdfbox.pdmodel.font.Standard14Fonts.FontName;
 import org.apache.pdfbox.pdmodel.font.encoding.BuiltInEncoding;
+import org.apache.pdfbox.pdmodel.font.encoding.DictionaryEncoding;
 import org.apache.pdfbox.pdmodel.font.encoding.Encoding;
 import org.apache.pdfbox.pdmodel.font.encoding.GlyphList;
 import org.apache.pdfbox.pdmodel.font.encoding.MacOSRomanEncoding;
@@ -621,39 +622,29 @@ public class PDTrueTypeFont extends PDSimpleFont implements PDVectorFont
             }
             else
             {
-                // (3, 1) - (Windows, Unicode)
-                if (cmapWinUnicode != null)
-                {
-                    String unicode = GlyphList.getAdobeGlyphList().toUnicode(name);
-                    if (unicode != null)
-                    {
-                        int uni = unicode.codePointAt(0);
-                        gid = cmapWinUnicode.getGlyphId(uni);
-                    }
-                }
-
-                // (1, 0) - (Macintosh, Roman)
-                if (gid == 0 && cmapMacRoman != null)
-                {
-                    Integer macCode = INVERTED_MACOS_ROMAN.get(name);
-                    if (macCode != null)
-                    {
-                        gid = cmapMacRoman.getGlyphId(macCode);
-                    }
-                }
-
-                // 'post' table
-                if (gid == 0)
-                {
-                    gid = ttf.nameToGID(name);
-                }
+                gid = codeToGIDByName(name);
             }
         }
         else // symbolic
         {
+            // PDFBOX-5960: some fonts have both the Symbolic and NonSymbolic flags set in their
+            // FontDescriptor, which is self-contradictory. When such a font also has an Encoding
+            // dictionary with a recognised /BaseEncoding, resolve the glyph by name first (as if
+            // the font were non-symbolic), and fall back to the code-based cmap lookup below only
+            // if that fails.
+            if (hasContradictorySymbolicFlags() && encoding instanceof DictionaryEncoding
+                    && isRecognizedBaseEncoding(((DictionaryEncoding) encoding).getBaseEncoding()))
+            {
+                String name = encoding.getName(code);
+                if (name != null && !".notdef".equals(name))
+                {
+                    gid = codeToGIDByName(name);
+                }
+            }
+
             // PDFBOX-4755 / PDF.js #5501
             // PDFBOX-3965: fallback for font has that the symbol flag but isn't
-            if (cmapWinUnicode != null)
+            if (gid == 0 && cmapWinUnicode != null)
             {
                 if (encoding instanceof WinAnsiEncoding || encoding instanceof MacRomanEncoding)
                 {
@@ -710,6 +701,70 @@ public class PDTrueTypeFont extends PDSimpleFont implements PDVectorFont
         }
 
         return gid;
+    }
+
+    /**
+     * Resolves a glyph name to a GID, the way a non-symbolic font would: via the (3, 1)
+     * Windows/Unicode cmap, the (1, 0) Macintosh/Roman cmap, or the 'post' table, in that order.
+     *
+     * @param name PostScript glyph name
+     * @return GID (glyph index), or 0 if none of the tables have a mapping for the name
+     */
+    private int codeToGIDByName(String name) throws IOException
+    {
+        int gid = 0;
+
+        // (3, 1) - (Windows, Unicode)
+        if (cmapWinUnicode != null)
+        {
+            String unicode = GlyphList.getAdobeGlyphList().toUnicode(name);
+            if (unicode != null)
+            {
+                int uni = unicode.codePointAt(0);
+                gid = cmapWinUnicode.getGlyphId(uni);
+            }
+        }
+
+        // (1, 0) - (Macintosh, Roman)
+        if (gid == 0 && cmapMacRoman != null)
+        {
+            Integer macCode = INVERTED_MACOS_ROMAN.get(name);
+            if (macCode != null)
+            {
+                gid = cmapMacRoman.getGlyphId(macCode);
+            }
+        }
+
+        // 'post' table
+        if (gid == 0)
+        {
+            gid = ttf.nameToGID(name);
+        }
+
+        return gid;
+    }
+
+    /**
+     * PDFBOX-5960: some malformed fonts have both the Symbolic and NonSymbolic flags set in
+     * their FontDescriptor, which is self-contradictory and means the Symbolic flag can't be
+     * trusted on its own.
+     *
+     * @return true if the font descriptor has both the Symbolic and NonSymbolic flags set
+     */
+    private boolean hasContradictorySymbolicFlags()
+    {
+        PDFontDescriptor fd = getFontDescriptor();
+        return fd != null && fd.isSymbolic() && fd.isNonSymbolic();
+    }
+
+    /**
+     * @return true if the given encoding is one of the standard named encodings, i.e. it came
+     * from a recognized /BaseEncoding entry rather than being synthesized as a fallback.
+     */
+    private static boolean isRecognizedBaseEncoding(Encoding encoding)
+    {
+        return encoding instanceof StandardEncoding || encoding instanceof WinAnsiEncoding
+                || encoding instanceof MacRomanEncoding;
     }
 
     /**


### PR DESCRIPTION
The bug: PDFBOX-5960 (https://issues.apache.org/jira/browse/PDFBOX-5960) is a regression (2.0.33+/3.0.4, worked in 1.8.16) where a diameter symbol fails to render. The attached font (ASCON HPDFAA+Symbol_A, from a "KOMPAS" export) has a malformed FontDescriptor where both the Symbolic (4) and NonSymbolic (32) flag bits are set — contradictory. It also has an /Encoding dictionary with /BaseEncoding /StandardEncoding and a /Differences array mapping code 71 > /Ccedilla.

PDTrueTypeFont.isSymbolic() trusted the raw Symbolic bit and took the "symbolic" code path, looking up glyph 71 directly through the font's (3,0) cmap — landing on GID 34 (post name "G", visually wrong). The correct glyph (the diameter symbol) is GID 90, reachable only by resolving the /Differences name "Ccedilla" through the post table, the way a non-symbolic font would.

The fix (pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/PDTrueTypeFont.java): in codeToGID(), when the descriptor has contradictory flags and the Encoding dictionary has a recognized /BaseEncoding, resolve by glyph name first, falling back to the existing code-based cmap logic only if that yields GID 0. Ordinary symbolic fonts (the common case) are untouched.

------------------------------
Test: https://github.com/apache/pdfbox/pull/522
------------------------------
Per https://www.apache.org/legal/generative-tooling.html: portions of this PR were
produced with assistance from Claude Code (Anthropic), based on a bug was described in Apache PDFBOX Issue Tracker.

I've reviewed the generated code and confirm to the best of my knowledge that the output does not include any
third-party copyrighted material and is compatible with the Apache License 2.0.