### PR TITLE
Fix typos in comments/javadoc

### DIFF
--- a/io/src/main/java/org/apache/pdfbox/io/IOUtils.java
+++ b/io/src/main/java/org/apache/pdfbox/io/IOUtils.java
@@ -411,7 +411,7 @@ public final class IOUtils
         try (Stream<Path> entries = Files.walk(path))
         {
             entries.sorted(Comparator.reverseOrder())
-                // we are using File.delete() on purpose over Files.deleteIfExists() which would be prefered in general, 
+                // we are using File.delete() on purpose over Files.deleteIfExists() which would be preferred in general, 
                 // as it's throwing a checked exception. As we are doing that in a shutdown hook there is not much we can
                 // do about it and a logger might no longer be available.
                 .forEach(p -> p.toFile().delete());

--- a/io/src/test/java/org/apache/pdfbox/io/RandomAccessReadMemoryMappedFileTest.java
+++ b/io/src/test/java/org/apache/pdfbox/io/RandomAccessReadMemoryMappedFileTest.java
@@ -183,7 +183,7 @@ class RandomAccessReadMemoryMappedFileTest
     @Test
     void testUnmapping() throws IOException
     {
-        // This is a special test case for some unmapping issues limited to windows enviroments
+        // This is a special test case for some unmapping issues limited to windows environments
         // see https://bugs.openjdk.java.net/browse/JDK-4724038
         Path tempFile = Files.createTempFile("PDFBOX", "txt");
         try (BufferedWriter bufferedWriter = Files.newBufferedWriter(tempFile, StandardOpenOption.WRITE))

--- a/xmpbox/src/test/java/org/apache/xmpbox/xml/DomXmpParserTest.java
+++ b/xmpbox/src/test/java/org/apache/xmpbox/xml/DomXmpParserTest.java
@@ -1496,7 +1496,7 @@ class DomXmpParserTest
         XMPMetadata xmp2 = xmpParser2.parse(s.getBytes(StandardCharsets.UTF_8));
         PhotoshopSchema photoshopSchema = xmp2.getPhotoshopSchema();
         assertNull(photoshopSchema.getHeadline());
-        // non existant properties are treated as text, one might want to change this in the future.
+        // non existent properties are treated as text, one might want to change this in the future.
         assertEquals("[headline=TextType:]", photoshopSchema.getProperty("headline").toString());
     }
 


### PR DESCRIPTION
Fix minor typos in comments/javadoc/log messages. No functional change.