### PR TITLE
Increase chunk-size cap in Filter.decode() for large streams

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/filter/Filter.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/filter/Filter.java
@@ -279,14 +279,20 @@ public abstract class Filter
                 length = randomAccessWriteBuffer.length();
             }
             // we don't know the size of the decoded stream, just estimate a 4 times bigger size than the encoded stream
-            // use the estimated stream size as chunk size, use the default chunk size as limit to avoid to big values
-            if (length <= 0 || length >= RandomAccessReadBuffer.DEFAULT_CHUNK_SIZE_4KB / 4)
+            // use the estimated stream size as chunk size, capped to avoid excessive per-chunk
+            // preallocation, but without collapsing back to the tiny default for large streams -
+            // that would otherwise force thousands of small chunk allocations
+            if (length <= 0)
             {
                 length = RandomAccessReadBuffer.DEFAULT_CHUNK_SIZE_4KB;
             }
             else
             {
-                length = length * 4;
+                // upper bound for the chunk size estimated from the encoded stream length in decode(), to
+                // avoid thousands of small chunk allocations for large streams while still bounding the
+                // worst-case preallocation for a single chunk
+                final int maxEstimatedChunkSize = 1 << 20;
+                length = Math.min(length, maxEstimatedChunkSize / 4) * 4;
             }
             randomAccessWriteBuffer = new RandomAccessReadWriteBuffer((int) length);
             output = new RandomAccessOutputStream(randomAccessWriteBuffer);


### PR DESCRIPTION
The buffer chunk-size estimate in the static decode() collapsed to the
flat 4KB default for any encoded stream >= 1KB, forcing thousands of
separate 4KB chunk allocations in RandomAccessReadWriteBuffer when
decoding large images/fonts. Cap the estimate at 1MB instead of
falling back to 4KB, cutting the number of chunk allocations for large
streams while still bounding worst-case preallocation