### PR TITLE
Fix pdfbox 5250

### DIFF
--- a/pdfbox/pom.xml
+++ b/pdfbox/pom.xml
@@ -1034,6 +1034,19 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>PDFBOX-5250</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>https://issues.apache.org/jira/secure/attachment/13073765/PDFBOX-5250-pattern-reduced3.pdf</url>
+                            <outputDirectory>${project.build.directory}/pdfs</outputDirectory>
+                            <outputFileName>PDFBOX-5250-pattern-reduced3.pdf</outputFileName>
+                            <sha512>fef1da8db49531a3bf017c6872b2032cac2d3c7e431f5529a80f87886b2d06455d086c9228ad35aee80d824ffb9e65e5ea302327b7feada001ede66f83199101</sha512>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>PDFBOX-5960</id>
                         <phase>generate-test-resources</phase>
                         <goals>

--- a/pdfbox/src/main/java/org/apache/pdfbox/contentstream/PDFStreamEngine.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/contentstream/PDFStreamEngine.java
@@ -239,13 +239,13 @@ public abstract class PDFStreamEngine
         Matrix parentMatrix = initialMatrix;
         PDGraphicsState graphicsState = getGraphicsState();
 
-        // the stream's initial matrix includes the parent CTM, e.g. this allows a scaled form
-        initialMatrix = graphicsState.getCurrentTransformationMatrix().clone();
-
         // transform the CTM using the stream's matrix
         graphicsState.getCurrentTransformationMatrix().concatenate(group.getMatrix());
 
-        // Before execution of the transparency group XObject’s content stream, 
+        // the stream's initial matrix includes the parent CTM, e.g. this allows a scaled form
+        initialMatrix = graphicsState.getCurrentTransformationMatrix().clone();
+
+        // Before execution of the transparency group XObject’s content stream,
         // the current blend mode in the graphics state shall be initialized to Normal, 
         // the current stroking and nonstroking alpha constants to 1.0, and the current soft mask to None.
         graphicsState.setBlendMode(BlendMode.NORMAL);

--- a/pdfbox/src/test/java/org/apache/pdfbox/rendering/TestQuality.java
+++ b/pdfbox/src/test/java/org/apache/pdfbox/rendering/TestQuality.java
@@ -126,4 +126,36 @@ class TestQuality
                     "expected a dark text pixel but was too light: " + Integer.toHexString(rgb));
         }
     }
+
+    /**
+     * PDFBOX-5250: a mesh shading pattern used inside a transparency group that has its own
+     * non-trivial /Matrix must be positioned using that group's own initial matrix, not the
+     * parent's. Before the fix, the transparency group's /Matrix was concatenated into the CTM
+     * only after the initial matrix had already been captured, so any pattern painted inside the
+     * group (here, a colored tiling pattern whose cell is itself a transparency group filled
+     * with a type 7 shading) was placed using the wrong reference matrix. That shifted the mesh
+     * shading far out of position, so instead of the intended multicolor gradient, only a
+     * single, mostly-green sliver of it ever landed on the visible glyphs.
+     *
+     * @throws IOException
+     */
+    @Test
+    void testPDFBox5250() throws IOException
+    {
+        File file = new File(TARGET_PDF_DIR, "PDFBOX-5250-pattern-reduced3.pdf");
+        try (PDDocument doc = Loader.loadPDF(file))
+        {
+            PDFRenderer renderer = new PDFRenderer(doc);
+            BufferedImage renderedImage = renderer.renderImageWithDPI(0, 100);
+            // a pixel within the shading-pattern-filled text; before the fix, the mesh shading
+            // was shifted out of view here, leaving this pixel blank white instead of the
+            // gradient's red-ish color. Checking red without also ruling out green isn't enough
+            // because white also has a maxed-out red channel.
+            int rgb = renderedImage.getRGB(190, 331);
+            int red = (rgb >> 16) & 0xFF;
+            int green = (rgb >> 8) & 0xFF;
+            Assertions.assertTrue(red > 150 && green < 150,
+                    "expected a red-ish gradient pixel but was: " + Integer.toHexString(rgb));
+        }
+    }
 }


### PR DESCRIPTION
In PDFStreamEngine.processTransparencyGroup(), initialMatrix was captured from the CTM before the transparency group's own /Matrix entry got concatenated into it — the opposite order used by processStream() (the code path for ordinary, non-group forms). Per spec, a pattern's matrix maps pattern space to "the default coordinate system of the pattern's parent content stream," which must include that stream's own /Matrix. So any shading/tiling pattern used inside a transparency group that itself has a non-trivial /Matrix (like the reported case's 0.017 scale) gets positioned using the wrong reference matrix — off by exactly that scale factor.