### PR TITLE
Consolidate command line options for tools in PDFBox and classes for the tools

### DIFF
--- a/tools/src/main/java/org/apache/pdfbox/tools/DecompressObjectstreams.java
+++ b/tools/src/main/java/org/apache/pdfbox/tools/DecompressObjectstreams.java
@@ -38,7 +38,7 @@ import picocli.CommandLine.Option;
  * 
  * @author Adam Nichols
  */
-@Command(name = "DecompressObjectstreams", header = "Decompresses object streams in a PDF file.")
+@Command(name = "decompress", header = "Decompresses object streams in a PDF file.")
 public final class DecompressObjectstreams implements Callable<Integer>
 {
     // Expected for CLI app to write to System.out/System.err

--- a/tools/src/main/java/org/apache/pdfbox/tools/ExportFDF.java
+++ b/tools/src/main/java/org/apache/pdfbox/tools/ExportFDF.java
@@ -36,7 +36,7 @@ import picocli.CommandLine.Option;
  *
  * @author Ben Litchfield
  */
-@Command(name = "exportfdf", header = "Exports AcroForm form data to FDF", versionProvider = Version.class, mixinStandardHelpOptions = true)
+@Command(name = "export:fdf", header = "Exports AcroForm form data to FDF", versionProvider = Version.class, mixinStandardHelpOptions = true)
 public final class ExportFDF implements Callable<Integer>
 {
     // Expected for CLI app to write to System.out/System.err

--- a/tools/src/main/java/org/apache/pdfbox/tools/ExportXFDF.java
+++ b/tools/src/main/java/org/apache/pdfbox/tools/ExportXFDF.java
@@ -37,7 +37,7 @@ import org.apache.pdfbox.pdmodel.fdf.FDFDocument;
  *
  * @author Ben Litchfield
  */
-@Command(name = "exportxfdf", header = "Exports AcroForm form data to XFDF", versionProvider = Version.class, mixinStandardHelpOptions = true)
+@Command(name = "export:xfdf", header = "Exports AcroForm form data to XFDF", versionProvider = Version.class, mixinStandardHelpOptions = true)
 public final class ExportXFDF implements Callable<Integer>
 {
     // Expected for CLI app to write to System.out/System.err

--- a/tools/src/main/java/org/apache/pdfbox/tools/ExtractImages.java
+++ b/tools/src/main/java/org/apache/pdfbox/tools/ExtractImages.java
@@ -66,7 +66,7 @@ import picocli.CommandLine.Option;
  *
  * @author Ben Litchfield
  */
-@Command(name = "extractimages", header = "Extracts the images from a PDF document", versionProvider = Version.class, mixinStandardHelpOptions = true)
+@Command(name = "export:images", header = "Extracts the images from a PDF document", versionProvider = Version.class, mixinStandardHelpOptions = true)
 public final class ExtractImages implements Callable<Integer>
 {
     // Expected for CLI app to write to System.out/System.err

--- a/tools/src/main/java/org/apache/pdfbox/tools/ExtractText.java
+++ b/tools/src/main/java/org/apache/pdfbox/tools/ExtractText.java
@@ -59,7 +59,7 @@ import picocli.CommandLine.Option;
  * @author Ben Litchfield
  * @author Tilman Hausherr
  */
-@Command(name = "extracttext", header = "Extracts the text from a PDF document", versionProvider = Version.class, mixinStandardHelpOptions = true)
+@Command(name = "export:text", header = "Extracts the text from a PDF document", versionProvider = Version.class, mixinStandardHelpOptions = true)
 public final class ExtractText  implements Callable<Integer>
 {
     private static final Logger LOG = LogManager.getLogger(ExtractText.class);

--- a/tools/src/main/java/org/apache/pdfbox/tools/ExtractXMP.java
+++ b/tools/src/main/java/org/apache/pdfbox/tools/ExtractXMP.java
@@ -37,7 +37,7 @@ import picocli.CommandLine;
  *
  * @author Tilman Hausherr
  */
-@CommandLine.Command(name = "extractxmp", header = "Extracts the xmp stream from a PDF document", versionProvider = Version.class, mixinStandardHelpOptions = true)
+@CommandLine.Command(name = "extract:xmp", header = "Extracts the xmp stream from a PDF document", versionProvider = Version.class, mixinStandardHelpOptions = true)
 public class ExtractXMP implements Callable<Integer>
 {
     // Expected for CLI app to write to System.out/System.err

--- a/tools/src/main/java/org/apache/pdfbox/tools/ImageToPDF.java
+++ b/tools/src/main/java/org/apache/pdfbox/tools/ImageToPDF.java
@@ -34,7 +34,7 @@ import picocli.CommandLine.Option;
 /**
  * Create a PDF document from images.
  */
-@Command(name = "imagetopdf", header = "Creates a PDF document from images", versionProvider = Version.class, mixinStandardHelpOptions = true)
+@Command(name = "fromimage", header = "Creates a PDF document from images", versionProvider = Version.class, mixinStandardHelpOptions = true)
 public final class ImageToPDF implements Callable<Integer>
 {
     private PDRectangle mediaBox = PDRectangle.LETTER;

--- a/tools/src/main/java/org/apache/pdfbox/tools/ImportFDF.java
+++ b/tools/src/main/java/org/apache/pdfbox/tools/ImportFDF.java
@@ -37,7 +37,7 @@ import picocli.CommandLine.Option;
  *
  * @author Ben Litchfield
  */
-@Command(name = "importfdf", header = "Imports AcroForm form data from FDF", versionProvider = Version.class, mixinStandardHelpOptions = true)
+@Command(name = "import:fdf", header = "Imports AcroForm form data from FDF", versionProvider = Version.class, mixinStandardHelpOptions = true)
 public class ImportFDF implements Callable<Integer>
 {
     // Expected for CLI app to write to System.out/System.err

--- a/tools/src/main/java/org/apache/pdfbox/tools/ImportXFDF.java
+++ b/tools/src/main/java/org/apache/pdfbox/tools/ImportXFDF.java
@@ -38,7 +38,7 @@ import java.util.concurrent.Callable;
  *
  * @author Ben Litchfield
  */
-@Command(name = "importxfdf", header = "Imports AcroForm form data from XFDF", versionProvider = Version.class, mixinStandardHelpOptions = true)
+@Command(name = "import:xfdf", header = "Imports AcroForm form data from XFDF", versionProvider = Version.class, mixinStandardHelpOptions = true)
 public class ImportXFDF implements Callable<Integer>
 {
     // Expected for CLI app to write to System.out/System.err

--- a/tools/src/main/java/org/apache/pdfbox/tools/OverlayPDF.java
+++ b/tools/src/main/java/org/apache/pdfbox/tools/OverlayPDF.java
@@ -38,7 +38,7 @@ import picocli.CommandLine.Option;
  * Based on code contributed by Balazs Jerk. 
  * 
  */
-@Command(name = "overlaypdf", header = "Adds an overlay to a PDF document", versionProvider = Version.class, mixinStandardHelpOptions = true)
+@Command(name = "overlay", header = "Adds an overlay to a PDF document", versionProvider = Version.class, mixinStandardHelpOptions = true)
 public final class OverlayPDF implements Callable<Integer>
 {
     // Expected for CLI app to write to System.out/System.err

--- a/tools/src/main/java/org/apache/pdfbox/tools/PDFBox.java
+++ b/tools/src/main/java/org/apache/pdfbox/tools/PDFBox.java
@@ -56,6 +56,7 @@ public final class PDFBox implements Runnable
         commandLine.addSubcommand("decrypt", Decrypt.class);
         commandLine.addSubcommand("encrypt", Encrypt.class);
         commandLine.addSubcommand("decode", WriteDecodedDoc.class);
+        commandLine.addSubcommand("decompress", DecompressObjectstreams.class);
         commandLine.addSubcommand("export:images", ExtractImages.class);
         commandLine.addSubcommand("export:xmp", ExtractXMP.class);
         commandLine.addSubcommand("export:text", ExtractText.class);

--- a/tools/src/main/java/org/apache/pdfbox/tools/PDFSplit.java
+++ b/tools/src/main/java/org/apache/pdfbox/tools/PDFSplit.java
@@ -38,7 +38,7 @@ import picocli.CommandLine.Option;
  *
  * @author Ben Litchfield
  */
-@Command(name = "pdfsplit", header = "Splits a PDF document into number of new documents", versionProvider = Version.class, mixinStandardHelpOptions = true)
+@Command(name = "split", header = "Splits a PDF document into number of new documents", versionProvider = Version.class, mixinStandardHelpOptions = true)
 public final class PDFSplit implements Callable<Integer>
 {
     // Expected for CLI app to write to System.out/System.err

--- a/tools/src/main/java/org/apache/pdfbox/tools/PDFToImage.java
+++ b/tools/src/main/java/org/apache/pdfbox/tools/PDFToImage.java
@@ -46,7 +46,7 @@ import picocli.CommandLine.Option;
  *
  * @author Ben Litchfield
  */
-@Command(name = "pdftoimage", header = "Converts a PDF document to image(s)", versionProvider = Version.class, mixinStandardHelpOptions = true)
+@Command(name = "render", header = "Converts a PDF document to image(s)", versionProvider = Version.class, mixinStandardHelpOptions = true)
 public final class PDFToImage implements Callable<Integer>
 {
     // Expected for CLI app to write to System.out/System.err

--- a/tools/src/main/java/org/apache/pdfbox/tools/TextToPDF.java
+++ b/tools/src/main/java/org/apache/pdfbox/tools/TextToPDF.java
@@ -47,7 +47,7 @@ import picocli.CommandLine.Option;
  *
  * @author Ben Litchfield
  */
-@Command(name = "texttopdf", header = "Creates a PDF document from text", versionProvider = Version.class, mixinStandardHelpOptions = true)
+@Command(name = "fromtext", header = "Creates a PDF document from text", versionProvider = Version.class, mixinStandardHelpOptions = true)
 public class TextToPDF implements Callable<Integer>
 {
     /**

--- a/tools/src/main/java/org/apache/pdfbox/tools/WriteDecodedDoc.java
+++ b/tools/src/main/java/org/apache/pdfbox/tools/WriteDecodedDoc.java
@@ -42,7 +42,7 @@ import picocli.CommandLine.Parameters;
  *
  * @author Michael Traut
  */
-@Command(name = "writedecodeddoc", header = "Writes a PDF document with all streams decoded", versionProvider = Version.class, mixinStandardHelpOptions = true)
+@Command(name = "decode", header = "Writes a PDF document with all streams decoded", versionProvider = Version.class, mixinStandardHelpOptions = true)
 public class WriteDecodedDoc implements Callable<Integer>
 {
     // Expected for CLI app to write to System.out/System.err


### PR DESCRIPTION

The names of the tools differ in tools/PDFBox.java and the classes of the individual tools.
This leads to misleading messages like the following:

java -jar pdfbox-app-4.0.0-trunk-SNAPSHOT.jar **export:text**
Missing required option: '--input=<infile>'
Extracts the text from a PDF document
Usage: pdfbox  **extracttext** [-hV] [-addFileName] [-alwaysNext] [-append]

The patch consolidates the names.

See https://issues.apache.org/jira/projects/PDFBOX/issues/PDFBOX-6262